### PR TITLE
case insensetive autocomplete

### DIFF
--- a/src/components/Shared/Autocomplete.tsx
+++ b/src/components/Shared/Autocomplete.tsx
@@ -81,7 +81,9 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
         } else {
             this.setState({
                 currentValue: e.target.value,
-                visibleItems: this.props.items.filter((i) => i.startsWith(e.target.value)),
+                visibleItems: this.props.items.filter((i) =>
+                    i.toLowerCase().startsWith(e.target.value.toLowerCase()),
+                ),
             });
         }
         this.props.onChange(e);


### PR DESCRIPTION
Hi!

Firstly thanks for making this tool its really cool!

Just added a small change to make autocomplete boxes cases insensitive, I think this would be useful as all the Pokémon names and route names are capitalized so it saves holding down the shift key, but still works if you start typing with the letter capitalized also.

I tested it running locally and all good, but was a little unsure of how to write a unit test for this.