### PR TITLE
Fix Vitest React runtime resolution and stabilize tests

### DIFF
--- a/src/components/Common/Shared/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/Common/Shared/__tests__/ErrorBoundary.test.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as sinon from "sinon";
 import { ErrorBoundary } from "..";
 import { screen, render } from "utils/testUtils";
 class ErroneousComponent extends React.Component {
@@ -20,16 +19,11 @@ describe("<ErroBoundary />", () => {
     });
 
     it("catches errors and renders errorMessage", () => {
-        const _spy = sinon.spy(ErrorBoundary.prototype, "componentDidCatch");
-        // the mount here triggers the error
         render(
-            <ErrorBoundary errorMessage={<div>Error!</div>}>
+            <ErrorBoundary errorMessage={<div data-testid="error">Error!</div>}>
                 <ErroneousComponent />
             </ErrorBoundary>,
         );
-        expect(ErrorBoundary.prototype.componentDidCatch).toHaveProperty(
-            "callCount",
-            1,
-        );
+        expect(screen.getByTestId("error").textContent).toBe("Error!");
     });
 });

--- a/src/utils/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/utils.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[` 1`] = `
 Array [
@@ -3513,6 +3513,3576 @@ Array [
   },
   Object {
     "Pecharunt": Array [],
+  },
+]
+`;
+
+exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
+[
+  {
+    "Bulbasaur": [],
+  },
+  {
+    "Ivysaur": [],
+  },
+  {
+    "Venusaur": [
+      "Mega",
+      "Gigantamax",
+    ],
+  },
+  {
+    "Charmander": [],
+  },
+  {
+    "Charmeleon": [],
+  },
+  {
+    "Charizard": [
+      "Mega-X",
+      "Mega-Y",
+      "Gigantamax",
+    ],
+  },
+  {
+    "Squirtle": [],
+  },
+  {
+    "Wartortle": [],
+  },
+  {
+    "Blastoise": [
+      "Mega",
+      "Gigantamax",
+    ],
+  },
+  {
+    "Caterpie": [],
+  },
+  {
+    "Metapod": [],
+  },
+  {
+    "Butterfree": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Weedle": [],
+  },
+  {
+    "Kakuna": [],
+  },
+  {
+    "Beedrill": [
+      "Mega",
+    ],
+  },
+  {
+    "Pidgey": [],
+  },
+  {
+    "Pidgeotto": [],
+  },
+  {
+    "Pidgeot": [
+      "Mega",
+    ],
+  },
+  {
+    "Rattata": [
+      "Alolan",
+    ],
+  },
+  {
+    "Raticate": [
+      "Alolan",
+    ],
+  },
+  {
+    "Spearow": [],
+  },
+  {
+    "Fearow": [],
+  },
+  {
+    "Ekans": [],
+  },
+  {
+    "Arbok": [],
+  },
+  {
+    "Pikachu": [
+      "Rock Star",
+      "Belle",
+      "Pop Star",
+      "Ph. D",
+      "Libre",
+      "Original Cap",
+      "Hoenn Cap",
+      "Sinnoh Cap",
+      "Unova Cap",
+      "Kalos Cap",
+      "Alola Cap",
+      "Partner Cap",
+      "Gigantamax",
+    ],
+  },
+  {
+    "Raichu": [
+      "Alolan",
+    ],
+  },
+  {
+    "Sandshrew": [
+      "Alolan",
+    ],
+  },
+  {
+    "Sandslash": [
+      "Alolan",
+    ],
+  },
+  {
+    "Nidoran♀": [],
+  },
+  {
+    "Nidorina": [],
+  },
+  {
+    "Nidoqueen": [],
+  },
+  {
+    "Nidoran♂": [],
+  },
+  {
+    "Nidorino": [],
+  },
+  {
+    "Nidoking": [],
+  },
+  {
+    "Clefairy": [],
+  },
+  {
+    "Clefable": [
+      "Mega",
+    ],
+  },
+  {
+    "Vulpix": [
+      "Alolan",
+    ],
+  },
+  {
+    "Ninetales": [
+      "Alolan",
+    ],
+  },
+  {
+    "Jigglypuff": [],
+  },
+  {
+    "Wigglytuff": [],
+  },
+  {
+    "Zubat": [],
+  },
+  {
+    "Golbat": [],
+  },
+  {
+    "Oddish": [],
+  },
+  {
+    "Gloom": [],
+  },
+  {
+    "Vileplume": [],
+  },
+  {
+    "Paras": [],
+  },
+  {
+    "Parasect": [],
+  },
+  {
+    "Venonat": [],
+  },
+  {
+    "Venomoth": [],
+  },
+  {
+    "Diglett": [
+      "Alolan",
+    ],
+  },
+  {
+    "Dugtrio": [
+      "Alolan",
+    ],
+  },
+  {
+    "Meowth": [
+      "Alolan",
+      "Galarian",
+    ],
+  },
+  {
+    "Persian": [
+      "Alolan",
+    ],
+  },
+  {
+    "Psyduck": [],
+  },
+  {
+    "Golduck": [],
+  },
+  {
+    "Mankey": [],
+  },
+  {
+    "Primeape": [],
+  },
+  {
+    "Growlithe": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Arcanine": [],
+  },
+  {
+    "Poliwag": [],
+  },
+  {
+    "Poliwhirl": [],
+  },
+  {
+    "Poliwrath": [],
+  },
+  {
+    "Abra": [],
+  },
+  {
+    "Kadabra": [],
+  },
+  {
+    "Alakazam": [
+      "Mega",
+    ],
+  },
+  {
+    "Machop": [],
+  },
+  {
+    "Machoke": [],
+  },
+  {
+    "Machamp": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Bellsprout": [],
+  },
+  {
+    "Weepinbell": [],
+  },
+  {
+    "Victreebel": [
+      "Mega",
+    ],
+  },
+  {
+    "Tentacool": [],
+  },
+  {
+    "Tentacruel": [],
+  },
+  {
+    "Geodude": [
+      "Alolan",
+    ],
+  },
+  {
+    "Graveler": [
+      "Alolan",
+    ],
+  },
+  {
+    "Golem": [
+      "Alolan",
+    ],
+  },
+  {
+    "Ponyta": [
+      "Galarian",
+    ],
+  },
+  {
+    "Rapidash": [
+      "Galarian",
+    ],
+  },
+  {
+    "Slowpoke": [
+      "Galarian",
+    ],
+  },
+  {
+    "Slowbro": [
+      "Galarian",
+      "Mega",
+    ],
+  },
+  {
+    "Magnemite": [],
+  },
+  {
+    "Magneton": [],
+  },
+  {
+    "Farfetch'd": [
+      "Galarian",
+    ],
+  },
+  {
+    "Doduo": [],
+  },
+  {
+    "Dodrio": [],
+  },
+  {
+    "Seel": [],
+  },
+  {
+    "Dewgong": [],
+  },
+  {
+    "Grimer": [
+      "Alolan",
+    ],
+  },
+  {
+    "Muk": [
+      "Alolan",
+    ],
+  },
+  {
+    "Shellder": [],
+  },
+  {
+    "Cloyster": [],
+  },
+  {
+    "Gastly": [],
+  },
+  {
+    "Haunter": [],
+  },
+  {
+    "Gengar": [
+      "Mega",
+      "Gigantamax",
+    ],
+  },
+  {
+    "Onix": [],
+  },
+  {
+    "Drowzee": [],
+  },
+  {
+    "Hypno": [],
+  },
+  {
+    "Krabby": [],
+  },
+  {
+    "Kingler": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Voltorb": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Electrode": [],
+  },
+  {
+    "Exeggcute": [],
+  },
+  {
+    "Exeggutor": [
+      "Alolan",
+    ],
+  },
+  {
+    "Cubone": [],
+  },
+  {
+    "Marowak": [
+      "Alolan",
+    ],
+  },
+  {
+    "Hitmonlee": [],
+  },
+  {
+    "Hitmonchan": [],
+  },
+  {
+    "Lickitung": [],
+  },
+  {
+    "Koffing": [],
+  },
+  {
+    "Weezing": [
+      "Galarian",
+    ],
+  },
+  {
+    "Rhyhorn": [],
+  },
+  {
+    "Rhydon": [],
+  },
+  {
+    "Chansey": [],
+  },
+  {
+    "Tangela": [],
+  },
+  {
+    "Kangaskhan": [
+      "Mega",
+    ],
+  },
+  {
+    "Horsea": [],
+  },
+  {
+    "Seadra": [],
+  },
+  {
+    "Goldeen": [],
+  },
+  {
+    "Seaking": [],
+  },
+  {
+    "Staryu": [],
+  },
+  {
+    "Starmie": [
+      "Mega",
+    ],
+  },
+  {
+    "Mr. Mime": [
+      "Galarian",
+    ],
+  },
+  {
+    "Scyther": [],
+  },
+  {
+    "Jynx": [],
+  },
+  {
+    "Electabuzz": [],
+  },
+  {
+    "Magmar": [],
+  },
+  {
+    "Pinsir": [
+      "Mega",
+    ],
+  },
+  {
+    "Tauros": [
+      "Paldean",
+      "Paldean-Aqua",
+      "Paldean-Blaze",
+    ],
+  },
+  {
+    "Magikarp": [],
+  },
+  {
+    "Gyarados": [
+      "Mega",
+    ],
+  },
+  {
+    "Lapras": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Ditto": [],
+  },
+  {
+    "Eevee": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Vaporeon": [],
+  },
+  {
+    "Jolteon": [],
+  },
+  {
+    "Flareon": [],
+  },
+  {
+    "Porygon": [],
+  },
+  {
+    "Omanyte": [],
+  },
+  {
+    "Omastar": [],
+  },
+  {
+    "Kabuto": [],
+  },
+  {
+    "Kabutops": [],
+  },
+  {
+    "Aerodactyl": [
+      "Mega",
+    ],
+  },
+  {
+    "Snorlax": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Articuno": [
+      "Galarian",
+    ],
+  },
+  {
+    "Zapdos": [
+      "Galarian",
+    ],
+  },
+  {
+    "Moltres": [
+      "Galarian",
+    ],
+  },
+  {
+    "Dratini": [],
+  },
+  {
+    "Dragonair": [],
+  },
+  {
+    "Dragonite": [
+      "Mega",
+    ],
+  },
+  {
+    "Mewtwo": [
+      "Mega-X",
+      "Mega-Y",
+    ],
+  },
+  {
+    "Mew": [],
+  },
+  {
+    "Chikorita": [],
+  },
+  {
+    "Bayleef": [],
+  },
+  {
+    "Meganium": [
+      "Mega",
+    ],
+  },
+  {
+    "Cyndaquil": [],
+  },
+  {
+    "Quilava": [],
+  },
+  {
+    "Typhlosion": [],
+  },
+  {
+    "Totodile": [],
+  },
+  {
+    "Croconaw": [],
+  },
+  {
+    "Feraligatr": [
+      "Mega",
+    ],
+  },
+  {
+    "Sentret": [],
+  },
+  {
+    "Furret": [],
+  },
+  {
+    "Hoothoot": [],
+  },
+  {
+    "Noctowl": [],
+  },
+  {
+    "Ledyba": [],
+  },
+  {
+    "Ledian": [],
+  },
+  {
+    "Spinarak": [],
+  },
+  {
+    "Ariados": [],
+  },
+  {
+    "Crobat": [],
+  },
+  {
+    "Chinchou": [],
+  },
+  {
+    "Lanturn": [],
+  },
+  {
+    "Pichu": [
+      "Spiky-eared",
+    ],
+  },
+  {
+    "Cleffa": [],
+  },
+  {
+    "Igglybuff": [],
+  },
+  {
+    "Togepi": [],
+  },
+  {
+    "Togetic": [],
+  },
+  {
+    "Natu": [],
+  },
+  {
+    "Xatu": [],
+  },
+  {
+    "Mareep": [],
+  },
+  {
+    "Flaaffy": [],
+  },
+  {
+    "Ampharos": [
+      "Mega",
+    ],
+  },
+  {
+    "Bellossom": [],
+  },
+  {
+    "Marill": [],
+  },
+  {
+    "Azumarill": [],
+  },
+  {
+    "Sudowoodo": [],
+  },
+  {
+    "Politoed": [],
+  },
+  {
+    "Hoppip": [],
+  },
+  {
+    "Skiploom": [],
+  },
+  {
+    "Jumpluff": [],
+  },
+  {
+    "Aipom": [],
+  },
+  {
+    "Sunkern": [],
+  },
+  {
+    "Sunflora": [],
+  },
+  {
+    "Yanma": [],
+  },
+  {
+    "Wooper": [
+      "Paldean",
+    ],
+  },
+  {
+    "Quagsire": [],
+  },
+  {
+    "Espeon": [],
+  },
+  {
+    "Umbreon": [],
+  },
+  {
+    "Murkrow": [],
+  },
+  {
+    "Slowking": [
+      "Galarian",
+    ],
+  },
+  {
+    "Misdreavus": [],
+  },
+  {
+    "Unown": [
+      "A",
+      "B",
+      "C",
+      "D",
+      "E",
+      "F",
+      "G",
+      "H",
+      "I",
+      "J",
+      "K",
+      "L",
+      "M",
+      "N",
+      "O",
+      "P",
+      "Q",
+      "R",
+      "S",
+      "T",
+      "U",
+      "V",
+      "W",
+      "X",
+      "Y",
+      "Z",
+      "!",
+      "?",
+    ],
+  },
+  {
+    "Wobbuffet": [],
+  },
+  {
+    "Girafarig": [],
+  },
+  {
+    "Pineco": [],
+  },
+  {
+    "Forretress": [],
+  },
+  {
+    "Dunsparce": [],
+  },
+  {
+    "Gligar": [],
+  },
+  {
+    "Steelix": [
+      "Mega",
+    ],
+  },
+  {
+    "Snubbull": [],
+  },
+  {
+    "Granbull": [],
+  },
+  {
+    "Qwilfish": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Scizor": [
+      "Mega",
+    ],
+  },
+  {
+    "Shuckle": [],
+  },
+  {
+    "Heracross": [
+      "Mega",
+    ],
+  },
+  {
+    "Sneasel": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Teddiursa": [],
+  },
+  {
+    "Ursaring": [],
+  },
+  {
+    "Slugma": [],
+  },
+  {
+    "Magcargo": [],
+  },
+  {
+    "Swinub": [],
+  },
+  {
+    "Piloswine": [],
+  },
+  {
+    "Corsola": [
+      "Galarian",
+    ],
+  },
+  {
+    "Remoraid": [],
+  },
+  {
+    "Octillery": [],
+  },
+  {
+    "Delibird": [],
+  },
+  {
+    "Mantine": [],
+  },
+  {
+    "Skarmory": [
+      "Mega",
+    ],
+  },
+  {
+    "Houndour": [],
+  },
+  {
+    "Houndoom": [
+      "Mega",
+    ],
+  },
+  {
+    "Kingdra": [],
+  },
+  {
+    "Phanpy": [],
+  },
+  {
+    "Donphan": [],
+  },
+  {
+    "Porygon2": [],
+  },
+  {
+    "Stantler": [],
+  },
+  {
+    "Smeargle": [],
+  },
+  {
+    "Tyrogue": [],
+  },
+  {
+    "Hitmontop": [],
+  },
+  {
+    "Smoochum": [],
+  },
+  {
+    "Elekid": [],
+  },
+  {
+    "Magby": [],
+  },
+  {
+    "Miltank": [],
+  },
+  {
+    "Blissey": [],
+  },
+  {
+    "Raikou": [],
+  },
+  {
+    "Entei": [],
+  },
+  {
+    "Suicune": [],
+  },
+  {
+    "Larvitar": [],
+  },
+  {
+    "Pupitar": [],
+  },
+  {
+    "Tyranitar": [
+      "Mega",
+    ],
+  },
+  {
+    "Lugia": [],
+  },
+  {
+    "Ho-Oh": [],
+  },
+  {
+    "Celebi": [],
+  },
+  {
+    "Treecko": [],
+  },
+  {
+    "Grovyle": [],
+  },
+  {
+    "Sceptile": [
+      "Mega",
+    ],
+  },
+  {
+    "Torchic": [],
+  },
+  {
+    "Combusken": [],
+  },
+  {
+    "Blaziken": [
+      "Mega",
+    ],
+  },
+  {
+    "Mudkip": [],
+  },
+  {
+    "Marshtomp": [],
+  },
+  {
+    "Swampert": [
+      "Mega",
+    ],
+  },
+  {
+    "Poochyena": [],
+  },
+  {
+    "Mightyena": [],
+  },
+  {
+    "Zigzagoon": [
+      "Galarian",
+    ],
+  },
+  {
+    "Linoone": [
+      "Galarian",
+    ],
+  },
+  {
+    "Wurmple": [],
+  },
+  {
+    "Silcoon": [],
+  },
+  {
+    "Beautifly": [],
+  },
+  {
+    "Cascoon": [],
+  },
+  {
+    "Dustox": [],
+  },
+  {
+    "Lotad": [],
+  },
+  {
+    "Lombre": [],
+  },
+  {
+    "Ludicolo": [],
+  },
+  {
+    "Seedot": [],
+  },
+  {
+    "Nuzleaf": [],
+  },
+  {
+    "Shiftry": [],
+  },
+  {
+    "Taillow": [],
+  },
+  {
+    "Swellow": [],
+  },
+  {
+    "Wingull": [],
+  },
+  {
+    "Pelipper": [],
+  },
+  {
+    "Ralts": [],
+  },
+  {
+    "Kirlia": [],
+  },
+  {
+    "Gardevoir": [
+      "Mega",
+    ],
+  },
+  {
+    "Surskit": [],
+  },
+  {
+    "Masquerain": [],
+  },
+  {
+    "Shroomish": [],
+  },
+  {
+    "Breloom": [],
+  },
+  {
+    "Slakoth": [],
+  },
+  {
+    "Vigoroth": [],
+  },
+  {
+    "Slaking": [],
+  },
+  {
+    "Nincada": [],
+  },
+  {
+    "Ninjask": [],
+  },
+  {
+    "Shedinja": [],
+  },
+  {
+    "Whismur": [],
+  },
+  {
+    "Loudred": [],
+  },
+  {
+    "Exploud": [],
+  },
+  {
+    "Makuhita": [],
+  },
+  {
+    "Hariyama": [],
+  },
+  {
+    "Azurill": [],
+  },
+  {
+    "Nosepass": [],
+  },
+  {
+    "Skitty": [],
+  },
+  {
+    "Delcatty": [],
+  },
+  {
+    "Sableye": [
+      "Mega",
+    ],
+  },
+  {
+    "Mawile": [
+      "Mega",
+    ],
+  },
+  {
+    "Aron": [],
+  },
+  {
+    "Lairon": [],
+  },
+  {
+    "Aggron": [
+      "Mega",
+    ],
+  },
+  {
+    "Meditite": [],
+  },
+  {
+    "Medicham": [
+      "Mega",
+    ],
+  },
+  {
+    "Electrike": [],
+  },
+  {
+    "Manectric": [
+      "Mega",
+    ],
+  },
+  {
+    "Plusle": [],
+  },
+  {
+    "Minun": [],
+  },
+  {
+    "Volbeat": [],
+  },
+  {
+    "Illumise": [],
+  },
+  {
+    "Roselia": [],
+  },
+  {
+    "Gulpin": [],
+  },
+  {
+    "Swalot": [],
+  },
+  {
+    "Carvanha": [],
+  },
+  {
+    "Sharpedo": [
+      "Mega",
+    ],
+  },
+  {
+    "Wailmer": [],
+  },
+  {
+    "Wailord": [],
+  },
+  {
+    "Numel": [],
+  },
+  {
+    "Camerupt": [
+      "Mega",
+    ],
+  },
+  {
+    "Torkoal": [],
+  },
+  {
+    "Spoink": [],
+  },
+  {
+    "Grumpig": [],
+  },
+  {
+    "Spinda": [],
+  },
+  {
+    "Trapinch": [],
+  },
+  {
+    "Vibrava": [],
+  },
+  {
+    "Flygon": [],
+  },
+  {
+    "Cacnea": [],
+  },
+  {
+    "Cacturne": [],
+  },
+  {
+    "Swablu": [],
+  },
+  {
+    "Altaria": [
+      "Mega",
+    ],
+  },
+  {
+    "Zangoose": [],
+  },
+  {
+    "Seviper": [],
+  },
+  {
+    "Lunatone": [],
+  },
+  {
+    "Solrock": [],
+  },
+  {
+    "Barboach": [],
+  },
+  {
+    "Whiscash": [],
+  },
+  {
+    "Corphish": [],
+  },
+  {
+    "Crawdaunt": [],
+  },
+  {
+    "Baltoy": [],
+  },
+  {
+    "Claydol": [],
+  },
+  {
+    "Lileep": [],
+  },
+  {
+    "Cradily": [],
+  },
+  {
+    "Anorith": [],
+  },
+  {
+    "Armaldo": [],
+  },
+  {
+    "Feebas": [],
+  },
+  {
+    "Milotic": [],
+  },
+  {
+    "Castform": [
+      "Sunny",
+      "Rainy",
+      "Snowy",
+    ],
+  },
+  {
+    "Kecleon": [],
+  },
+  {
+    "Shuppet": [],
+  },
+  {
+    "Banette": [
+      "Mega",
+    ],
+  },
+  {
+    "Duskull": [],
+  },
+  {
+    "Dusclops": [],
+  },
+  {
+    "Tropius": [],
+  },
+  {
+    "Chimecho": [],
+  },
+  {
+    "Absol": [
+      "Mega",
+    ],
+  },
+  {
+    "Wynaut": [],
+  },
+  {
+    "Snorunt": [],
+  },
+  {
+    "Glalie": [
+      "Mega",
+    ],
+  },
+  {
+    "Spheal": [],
+  },
+  {
+    "Sealeo": [],
+  },
+  {
+    "Walrein": [],
+  },
+  {
+    "Clamperl": [],
+  },
+  {
+    "Huntail": [],
+  },
+  {
+    "Gorebyss": [],
+  },
+  {
+    "Relicanth": [],
+  },
+  {
+    "Luvdisc": [],
+  },
+  {
+    "Bagon": [],
+  },
+  {
+    "Shelgon": [],
+  },
+  {
+    "Salamence": [
+      "Mega",
+    ],
+  },
+  {
+    "Beldum": [],
+  },
+  {
+    "Metang": [],
+  },
+  {
+    "Metagross": [
+      "Mega",
+    ],
+  },
+  {
+    "Regirock": [],
+  },
+  {
+    "Regice": [],
+  },
+  {
+    "Registeel": [],
+  },
+  {
+    "Latias": [
+      "Mega",
+    ],
+  },
+  {
+    "Latios": [
+      "Mega",
+    ],
+  },
+  {
+    "Kyogre": [
+      "Primal",
+    ],
+  },
+  {
+    "Groudon": [
+      "Primal",
+    ],
+  },
+  {
+    "Rayquaza": [
+      "Mega",
+    ],
+  },
+  {
+    "Jirachi": [],
+  },
+  {
+    "Deoxys": [
+      "Attack",
+      "Defense",
+      "Speed",
+    ],
+  },
+  {
+    "Turtwig": [],
+  },
+  {
+    "Grotle": [],
+  },
+  {
+    "Torterra": [],
+  },
+  {
+    "Chimchar": [],
+  },
+  {
+    "Monferno": [],
+  },
+  {
+    "Infernape": [],
+  },
+  {
+    "Piplup": [],
+  },
+  {
+    "Prinplup": [],
+  },
+  {
+    "Empoleon": [],
+  },
+  {
+    "Starly": [],
+  },
+  {
+    "Staravia": [],
+  },
+  {
+    "Staraptor": [],
+  },
+  {
+    "Bidoof": [],
+  },
+  {
+    "Bibarel": [],
+  },
+  {
+    "Kricketot": [],
+  },
+  {
+    "Kricketune": [],
+  },
+  {
+    "Shinx": [],
+  },
+  {
+    "Luxio": [],
+  },
+  {
+    "Luxray": [],
+  },
+  {
+    "Budew": [],
+  },
+  {
+    "Roserade": [],
+  },
+  {
+    "Cranidos": [],
+  },
+  {
+    "Rampardos": [],
+  },
+  {
+    "Shieldon": [],
+  },
+  {
+    "Bastiodon": [],
+  },
+  {
+    "Burmy": [
+      "Plant",
+      "Sandy",
+      "Trash",
+    ],
+  },
+  {
+    "Wormadam": [
+      "Plant",
+      "Sandy",
+      "Trash",
+    ],
+  },
+  {
+    "Mothim": [],
+  },
+  {
+    "Combee": [],
+  },
+  {
+    "Vespiquen": [],
+  },
+  {
+    "Pachirisu": [],
+  },
+  {
+    "Buizel": [],
+  },
+  {
+    "Floatzel": [],
+  },
+  {
+    "Cherubi": [],
+  },
+  {
+    "Cherrim": [],
+  },
+  {
+    "Shellos": [
+      "West Sea",
+      "East Sea",
+    ],
+  },
+  {
+    "Gastrodon": [
+      "West Sea",
+      "East Sea",
+    ],
+  },
+  {
+    "Ambipom": [],
+  },
+  {
+    "Drifloon": [],
+  },
+  {
+    "Drifblim": [],
+  },
+  {
+    "Buneary": [],
+  },
+  {
+    "Lopunny": [
+      "Mega",
+    ],
+  },
+  {
+    "Mismagius": [],
+  },
+  {
+    "Honchkrow": [],
+  },
+  {
+    "Glameow": [],
+  },
+  {
+    "Purugly": [],
+  },
+  {
+    "Chingling": [],
+  },
+  {
+    "Stunky": [],
+  },
+  {
+    "Skuntank": [],
+  },
+  {
+    "Bronzor": [],
+  },
+  {
+    "Bronzong": [],
+  },
+  {
+    "Bonsly": [],
+  },
+  {
+    "Mime Jr.": [],
+  },
+  {
+    "Happiny": [],
+  },
+  {
+    "Chatot": [],
+  },
+  {
+    "Spiritomb": [],
+  },
+  {
+    "Gible": [],
+  },
+  {
+    "Gabite": [],
+  },
+  {
+    "Garchomp": [
+      "Mega",
+    ],
+  },
+  {
+    "Munchlax": [],
+  },
+  {
+    "Riolu": [],
+  },
+  {
+    "Lucario": [
+      "Mega",
+    ],
+  },
+  {
+    "Hippopotas": [],
+  },
+  {
+    "Hippowdon": [],
+  },
+  {
+    "Skorupi": [],
+  },
+  {
+    "Drapion": [],
+  },
+  {
+    "Croagunk": [],
+  },
+  {
+    "Toxicroak": [],
+  },
+  {
+    "Carnivine": [],
+  },
+  {
+    "Finneon": [],
+  },
+  {
+    "Lumineon": [],
+  },
+  {
+    "Mantyke": [],
+  },
+  {
+    "Snover": [],
+  },
+  {
+    "Abomasnow": [
+      "Mega",
+    ],
+  },
+  {
+    "Weavile": [],
+  },
+  {
+    "Magnezone": [],
+  },
+  {
+    "Lickilicky": [],
+  },
+  {
+    "Rhyperior": [],
+  },
+  {
+    "Tangrowth": [],
+  },
+  {
+    "Electivire": [],
+  },
+  {
+    "Magmortar": [],
+  },
+  {
+    "Togekiss": [],
+  },
+  {
+    "Yanmega": [],
+  },
+  {
+    "Leafeon": [],
+  },
+  {
+    "Glaceon": [],
+  },
+  {
+    "Gliscor": [],
+  },
+  {
+    "Mamoswine": [],
+  },
+  {
+    "Porygon-Z": [],
+  },
+  {
+    "Gallade": [
+      "Mega",
+    ],
+  },
+  {
+    "Probopass": [],
+  },
+  {
+    "Dusknoir": [],
+  },
+  {
+    "Froslass": [
+      "Mega",
+    ],
+  },
+  {
+    "Rotom": [
+      "Heat",
+      "Wash",
+      "Frost",
+      "Fan",
+      "Mow",
+    ],
+  },
+  {
+    "Uxie": [],
+  },
+  {
+    "Mesprit": [],
+  },
+  {
+    "Azelf": [],
+  },
+  {
+    "Dialga": [],
+  },
+  {
+    "Palkia": [],
+  },
+  {
+    "Heatran": [],
+  },
+  {
+    "Regigigas": [],
+  },
+  {
+    "Giratina": [
+      "Altered",
+      "Origin",
+    ],
+  },
+  {
+    "Cresselia": [],
+  },
+  {
+    "Phione": [],
+  },
+  {
+    "Manaphy": [],
+  },
+  {
+    "Darkrai": [],
+  },
+  {
+    "Shaymin": [
+      "Land",
+      "Sky",
+    ],
+  },
+  {
+    "Arceus": [],
+  },
+  {
+    "Victini": [],
+  },
+  {
+    "Snivy": [],
+  },
+  {
+    "Servine": [],
+  },
+  {
+    "Serperior": [],
+  },
+  {
+    "Tepig": [],
+  },
+  {
+    "Pignite": [],
+  },
+  {
+    "Emboar": [
+      "Mega",
+    ],
+  },
+  {
+    "Oshawott": [],
+  },
+  {
+    "Dewott": [],
+  },
+  {
+    "Samurott": [],
+  },
+  {
+    "Patrat": [],
+  },
+  {
+    "Watchog": [],
+  },
+  {
+    "Lillipup": [],
+  },
+  {
+    "Herdier": [],
+  },
+  {
+    "Stoutland": [],
+  },
+  {
+    "Purrloin": [],
+  },
+  {
+    "Liepard": [],
+  },
+  {
+    "Pansage": [],
+  },
+  {
+    "Simisage": [],
+  },
+  {
+    "Pansear": [],
+  },
+  {
+    "Simisear": [],
+  },
+  {
+    "Panpour": [],
+  },
+  {
+    "Simipour": [],
+  },
+  {
+    "Munna": [],
+  },
+  {
+    "Musharna": [],
+  },
+  {
+    "Pidove": [],
+  },
+  {
+    "Tranquill": [],
+  },
+  {
+    "Unfezant": [],
+  },
+  {
+    "Blitzle": [],
+  },
+  {
+    "Zebstrika": [],
+  },
+  {
+    "Roggenrola": [],
+  },
+  {
+    "Boldore": [],
+  },
+  {
+    "Gigalith": [],
+  },
+  {
+    "Woobat": [],
+  },
+  {
+    "Swoobat": [],
+  },
+  {
+    "Drilbur": [],
+  },
+  {
+    "Excadrill": [
+      "Mega",
+    ],
+  },
+  {
+    "Audino": [
+      "Mega",
+    ],
+  },
+  {
+    "Timburr": [],
+  },
+  {
+    "Gurdurr": [],
+  },
+  {
+    "Conkeldurr": [],
+  },
+  {
+    "Tympole": [],
+  },
+  {
+    "Palpitoad": [],
+  },
+  {
+    "Seismitoad": [],
+  },
+  {
+    "Throh": [],
+  },
+  {
+    "Sawk": [],
+  },
+  {
+    "Sewaddle": [],
+  },
+  {
+    "Swadloon": [],
+  },
+  {
+    "Leavanny": [],
+  },
+  {
+    "Venipede": [],
+  },
+  {
+    "Whirlipede": [],
+  },
+  {
+    "Scolipede": [
+      "Mega",
+    ],
+  },
+  {
+    "Cottonee": [],
+  },
+  {
+    "Whimsicott": [],
+  },
+  {
+    "Petilil": [],
+  },
+  {
+    "Lilligant": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Basculin": [
+      "Red-Striped",
+      "Blue-Striped",
+      "White-Striped",
+    ],
+  },
+  {
+    "Sandile": [],
+  },
+  {
+    "Krokorok": [],
+  },
+  {
+    "Krookodile": [],
+  },
+  {
+    "Darumaka": [
+      "Galarian",
+    ],
+  },
+  {
+    "Darmanitan": [
+      "Galarian",
+    ],
+  },
+  {
+    "Maractus": [],
+  },
+  {
+    "Dwebble": [],
+  },
+  {
+    "Crustle": [],
+  },
+  {
+    "Scraggy": [],
+  },
+  {
+    "Scrafty": [
+      "Mega",
+    ],
+  },
+  {
+    "Sigilyph": [],
+  },
+  {
+    "Yamask": [
+      "Galarian",
+    ],
+  },
+  {
+    "Cofagrigus": [],
+  },
+  {
+    "Tirtouga": [],
+  },
+  {
+    "Carracosta": [],
+  },
+  {
+    "Archen": [],
+  },
+  {
+    "Archeops": [],
+  },
+  {
+    "Trubbish": [],
+  },
+  {
+    "Garbodor": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Zorua": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Zoroark": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Minccino": [],
+  },
+  {
+    "Cinccino": [],
+  },
+  {
+    "Gothita": [],
+  },
+  {
+    "Gothorita": [],
+  },
+  {
+    "Gothitelle": [],
+  },
+  {
+    "Solosis": [],
+  },
+  {
+    "Duosion": [],
+  },
+  {
+    "Reuniclus": [],
+  },
+  {
+    "Ducklett": [],
+  },
+  {
+    "Swanna": [],
+  },
+  {
+    "Vanillite": [],
+  },
+  {
+    "Vanillish": [],
+  },
+  {
+    "Vanilluxe": [],
+  },
+  {
+    "Deerling": [
+      "Spring",
+      "Summer",
+      "Autumn",
+      "Winter",
+    ],
+  },
+  {
+    "Sawsbuck": [
+      "Spring",
+      "Summer",
+      "Autumn",
+      "Winter",
+    ],
+  },
+  {
+    "Emolga": [],
+  },
+  {
+    "Karrablast": [],
+  },
+  {
+    "Escavalier": [],
+  },
+  {
+    "Foongus": [],
+  },
+  {
+    "Amoonguss": [],
+  },
+  {
+    "Frillish": [],
+  },
+  {
+    "Jellicent": [],
+  },
+  {
+    "Alomomola": [],
+  },
+  {
+    "Joltik": [],
+  },
+  {
+    "Galvantula": [],
+  },
+  {
+    "Ferroseed": [],
+  },
+  {
+    "Ferrothorn": [],
+  },
+  {
+    "Klink": [],
+  },
+  {
+    "Klang": [],
+  },
+  {
+    "Klinklang": [],
+  },
+  {
+    "Tynamo": [],
+  },
+  {
+    "Eelektrik": [],
+  },
+  {
+    "Eelektross": [
+      "Mega",
+    ],
+  },
+  {
+    "Elgyem": [],
+  },
+  {
+    "Beheeyem": [],
+  },
+  {
+    "Litwick": [],
+  },
+  {
+    "Lampent": [],
+  },
+  {
+    "Chandelure": [
+      "Mega",
+    ],
+  },
+  {
+    "Axew": [],
+  },
+  {
+    "Fraxure": [],
+  },
+  {
+    "Haxorus": [],
+  },
+  {
+    "Cubchoo": [],
+  },
+  {
+    "Beartic": [],
+  },
+  {
+    "Cryogonal": [],
+  },
+  {
+    "Shelmet": [],
+  },
+  {
+    "Accelgor": [],
+  },
+  {
+    "Stunfisk": [
+      "Galarian",
+    ],
+  },
+  {
+    "Mienfoo": [],
+  },
+  {
+    "Mienshao": [],
+  },
+  {
+    "Druddigon": [],
+  },
+  {
+    "Golett": [],
+  },
+  {
+    "Golurk": [],
+  },
+  {
+    "Pawniard": [],
+  },
+  {
+    "Bisharp": [],
+  },
+  {
+    "Bouffalant": [],
+  },
+  {
+    "Rufflet": [],
+  },
+  {
+    "Braviary": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Vullaby": [],
+  },
+  {
+    "Mandibuzz": [],
+  },
+  {
+    "Heatmor": [],
+  },
+  {
+    "Durant": [],
+  },
+  {
+    "Deino": [],
+  },
+  {
+    "Zweilous": [],
+  },
+  {
+    "Hydreigon": [],
+  },
+  {
+    "Larvesta": [],
+  },
+  {
+    "Volcarona": [],
+  },
+  {
+    "Cobalion": [],
+  },
+  {
+    "Terrakion": [],
+  },
+  {
+    "Virizion": [],
+  },
+  {
+    "Tornadus": [
+      "Incarnate",
+      "Therian",
+    ],
+  },
+  {
+    "Thundurus": [
+      "Incarnate",
+      "Therian",
+    ],
+  },
+  {
+    "Reshiram": [],
+  },
+  {
+    "Zekrom": [],
+  },
+  {
+    "Landorus": [
+      "Incarnate",
+      "Therian",
+    ],
+  },
+  {
+    "Kyurem": [
+      "White",
+      "Black",
+    ],
+  },
+  {
+    "Keldeo": [
+      "Resolute",
+    ],
+  },
+  {
+    "Meloetta": [
+      "Aria",
+      "Pirouette",
+    ],
+  },
+  {
+    "Genesect": [
+      "Shock Drive",
+      "Burn Drive",
+      "Chill Drive",
+      "Douse Drive",
+    ],
+  },
+  {
+    "Chespin": [],
+  },
+  {
+    "Quilladin": [],
+  },
+  {
+    "Chesnaught": [],
+  },
+  {
+    "Fennekin": [],
+  },
+  {
+    "Braixen": [],
+  },
+  {
+    "Delphox": [
+      "Mega",
+    ],
+  },
+  {
+    "Froakie": [],
+  },
+  {
+    "Frogadier": [],
+  },
+  {
+    "Greninja": [
+      "Mega",
+    ],
+  },
+  {
+    "Bunnelby": [],
+  },
+  {
+    "Diggersby": [],
+  },
+  {
+    "Fletchling": [],
+  },
+  {
+    "Fletchinder": [],
+  },
+  {
+    "Talonflame": [],
+  },
+  {
+    "Scatterbug": [],
+  },
+  {
+    "Spewpa": [],
+  },
+  {
+    "Vivillon": [],
+  },
+  {
+    "Litleo": [],
+  },
+  {
+    "Pyroar": [
+      "Mega",
+    ],
+  },
+  {
+    "Flabébé": [
+      "Red",
+      "Yellow",
+      "Orange",
+      "Blue",
+      "White",
+    ],
+  },
+  {
+    "Floette": [
+      "Red",
+      "Yellow",
+      "Orange",
+      "Blue",
+      "White",
+      "Eternal Flower",
+    ],
+  },
+  {
+    "Florges": [
+      "Red",
+      "Yellow",
+      "Orange",
+      "Blue",
+      "White",
+    ],
+  },
+  {
+    "Skiddo": [],
+  },
+  {
+    "Gogoat": [],
+  },
+  {
+    "Pancham": [],
+  },
+  {
+    "Pangoro": [],
+  },
+  {
+    "Furfrou": [
+      "Heart",
+      "Diamond",
+      "Star",
+      "Pharaoh",
+      "Kabuki",
+      "La Reine",
+      "Matron",
+      "Dandy",
+      "Debutante",
+    ],
+  },
+  {
+    "Espurr": [],
+  },
+  {
+    "Meowstic": [],
+  },
+  {
+    "Honedge": [],
+  },
+  {
+    "Doublade": [],
+  },
+  {
+    "Aegislash": [],
+  },
+  {
+    "Spritzee": [],
+  },
+  {
+    "Aromatisse": [],
+  },
+  {
+    "Swirlix": [],
+  },
+  {
+    "Slurpuff": [],
+  },
+  {
+    "Inkay": [],
+  },
+  {
+    "Malamar": [
+      "Mega",
+    ],
+  },
+  {
+    "Binacle": [],
+  },
+  {
+    "Barbaracle": [
+      "Mega",
+    ],
+  },
+  {
+    "Skrelp": [],
+  },
+  {
+    "Dragalge": [],
+  },
+  {
+    "Clauncher": [],
+  },
+  {
+    "Clawitzer": [],
+  },
+  {
+    "Helioptile": [],
+  },
+  {
+    "Heliolisk": [],
+  },
+  {
+    "Tyrunt": [],
+  },
+  {
+    "Tyrantrum": [],
+  },
+  {
+    "Amaura": [],
+  },
+  {
+    "Aurorus": [],
+  },
+  {
+    "Sylveon": [],
+  },
+  {
+    "Hawlucha": [
+      "Mega",
+    ],
+  },
+  {
+    "Dedenne": [],
+  },
+  {
+    "Carbink": [],
+  },
+  {
+    "Goomy": [],
+  },
+  {
+    "Sliggoo": [],
+  },
+  {
+    "Goodra": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Klefki": [],
+  },
+  {
+    "Phantump": [],
+  },
+  {
+    "Trevenant": [],
+  },
+  {
+    "Pumpkaboo": [],
+  },
+  {
+    "Gourgeist": [],
+  },
+  {
+    "Bergmite": [],
+  },
+  {
+    "Avalugg": [
+      "Hisuian",
+    ],
+  },
+  {
+    "Noibat": [],
+  },
+  {
+    "Noivern": [],
+  },
+  {
+    "Xerneas": [],
+  },
+  {
+    "Yveltal": [],
+  },
+  {
+    "Zygarde": [
+      "10%",
+      "Complete",
+    ],
+  },
+  {
+    "Diancie": [
+      "Mega",
+    ],
+  },
+  {
+    "Hoopa": [
+      "Confined",
+      "Unbound",
+    ],
+  },
+  {
+    "Volcanion": [],
+  },
+  {
+    "Rowlet": [],
+  },
+  {
+    "Dartrix": [],
+  },
+  {
+    "Decidueye": [],
+  },
+  {
+    "Litten": [],
+  },
+  {
+    "Torracat": [],
+  },
+  {
+    "Incineroar": [],
+  },
+  {
+    "Popplio": [],
+  },
+  {
+    "Brionne": [],
+  },
+  {
+    "Primarina": [],
+  },
+  {
+    "Pikipek": [],
+  },
+  {
+    "Trumbeak": [],
+  },
+  {
+    "Toucannon": [],
+  },
+  {
+    "Yungoos": [],
+  },
+  {
+    "Gumshoos": [],
+  },
+  {
+    "Grubbin": [],
+  },
+  {
+    "Charjabug": [],
+  },
+  {
+    "Vikavolt": [],
+  },
+  {
+    "Crabrawler": [],
+  },
+  {
+    "Crabominable": [],
+  },
+  {
+    "Oricorio": [
+      "Baile",
+      "Pom-Pom",
+      "Pa'u",
+      "Sensu",
+    ],
+  },
+  {
+    "Cutiefly": [],
+  },
+  {
+    "Ribombee": [],
+  },
+  {
+    "Rockruff": [],
+  },
+  {
+    "Lycanroc": [
+      "Midday",
+      "Midnight",
+      "Dusk",
+    ],
+  },
+  {
+    "Wishiwashi": [
+      "Solo",
+      "School",
+    ],
+  },
+  {
+    "Mareanie": [],
+  },
+  {
+    "Toxapex": [],
+  },
+  {
+    "Mudbray": [],
+  },
+  {
+    "Mudsdale": [],
+  },
+  {
+    "Dewpider": [],
+  },
+  {
+    "Araquanid": [],
+  },
+  {
+    "Fomantis": [],
+  },
+  {
+    "Lurantis": [],
+  },
+  {
+    "Morelull": [],
+  },
+  {
+    "Shiinotic": [],
+  },
+  {
+    "Salandit": [],
+  },
+  {
+    "Salazzle": [],
+  },
+  {
+    "Stufful": [],
+  },
+  {
+    "Bewear": [],
+  },
+  {
+    "Bounsweet": [],
+  },
+  {
+    "Steenee": [],
+  },
+  {
+    "Tsareena": [],
+  },
+  {
+    "Comfey": [],
+  },
+  {
+    "Oranguru": [],
+  },
+  {
+    "Passimian": [],
+  },
+  {
+    "Wimpod": [],
+  },
+  {
+    "Golisopod": [],
+  },
+  {
+    "Sandygast": [],
+  },
+  {
+    "Palossand": [],
+  },
+  {
+    "Pyukumuku": [],
+  },
+  {
+    "Type: Null": [],
+  },
+  {
+    "Silvally": [],
+  },
+  {
+    "Minior": [],
+  },
+  {
+    "Komala": [],
+  },
+  {
+    "Turtonator": [],
+  },
+  {
+    "Togedemaru": [],
+  },
+  {
+    "Mimikyu": [],
+  },
+  {
+    "Bruxish": [],
+  },
+  {
+    "Drampa": [
+      "Mega",
+    ],
+  },
+  {
+    "Dhelmise": [],
+  },
+  {
+    "Jangmo-o": [],
+  },
+  {
+    "Hakamo-o": [],
+  },
+  {
+    "Kommo-o": [],
+  },
+  {
+    "Tapu Koko": [],
+  },
+  {
+    "Tapu Lele": [],
+  },
+  {
+    "Tapu Bulu": [],
+  },
+  {
+    "Tapu Fini": [],
+  },
+  {
+    "Cosmog": [],
+  },
+  {
+    "Cosmoem": [],
+  },
+  {
+    "Solgaleo": [],
+  },
+  {
+    "Lunala": [],
+  },
+  {
+    "Nihilego": [],
+  },
+  {
+    "Buzzwole": [],
+  },
+  {
+    "Pheromosa": [],
+  },
+  {
+    "Xurkitree": [],
+  },
+  {
+    "Celesteela": [],
+  },
+  {
+    "Kartana": [],
+  },
+  {
+    "Guzzlord": [],
+  },
+  {
+    "Necrozma": [
+      "Dusk Mane",
+      "Dawn Wings",
+      "Ultra",
+    ],
+  },
+  {
+    "Magearna": [],
+  },
+  {
+    "Marshadow": [],
+  },
+  {
+    "Poipole": [],
+  },
+  {
+    "Naganadel": [],
+  },
+  {
+    "Stakataka": [],
+  },
+  {
+    "Blacephalon": [],
+  },
+  {
+    "Zeraora": [],
+  },
+  {
+    "Meltan": [],
+  },
+  {
+    "Melmetal": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Grookey": [],
+  },
+  {
+    "Thwackey": [],
+  },
+  {
+    "Rillaboom": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Scorbunny": [],
+  },
+  {
+    "Raboot": [],
+  },
+  {
+    "Cinderace": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Sobble": [],
+  },
+  {
+    "Drizzile": [],
+  },
+  {
+    "Inteleon": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Skwovet": [],
+  },
+  {
+    "Greedent": [],
+  },
+  {
+    "Rookidee": [],
+  },
+  {
+    "Corvisquire": [],
+  },
+  {
+    "Corviknight": [],
+  },
+  {
+    "Blipbug": [],
+  },
+  {
+    "Dottler": [],
+  },
+  {
+    "Orbeetle": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Nickit": [],
+  },
+  {
+    "Thievul": [],
+  },
+  {
+    "Gossifleur": [],
+  },
+  {
+    "Eldegoss": [],
+  },
+  {
+    "Wooloo": [],
+  },
+  {
+    "Dubwool": [],
+  },
+  {
+    "Chewtle": [],
+  },
+  {
+    "Drednaw": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Yamper": [],
+  },
+  {
+    "Boltund": [],
+  },
+  {
+    "Rolycoly": [],
+  },
+  {
+    "Carkol": [],
+  },
+  {
+    "Coalossal": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Applin": [],
+  },
+  {
+    "Flapple": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Appletun": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Silicobra": [],
+  },
+  {
+    "Sandaconda": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Cramorant": [],
+  },
+  {
+    "Arrokuda": [],
+  },
+  {
+    "Barraskewda": [],
+  },
+  {
+    "Toxel": [],
+  },
+  {
+    "Toxtricity": [
+      "Amped-Up",
+      "Lowkey",
+      "Gigantamax",
+    ],
+  },
+  {
+    "Sizzlipede": [],
+  },
+  {
+    "Centiskorch": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Clobbopus": [],
+  },
+  {
+    "Grapploct": [],
+  },
+  {
+    "Sinistea": [],
+  },
+  {
+    "Polteageist": [],
+  },
+  {
+    "Hatenna": [],
+  },
+  {
+    "Hattrem": [],
+  },
+  {
+    "Hatterene": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Impidimp": [],
+  },
+  {
+    "Morgrem": [],
+  },
+  {
+    "Grimmsnarl": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Obstagoon": [],
+  },
+  {
+    "Perrserker": [],
+  },
+  {
+    "Cursola": [],
+  },
+  {
+    "Sirfetch'd": [],
+  },
+  {
+    "Mr. Rime": [],
+  },
+  {
+    "Runerigus": [],
+  },
+  {
+    "Milcery": [],
+  },
+  {
+    "Alcremie": [
+      "Vanilla Cream",
+      "Matcha Cream",
+      "Ruby Cream",
+      "Mint Cream",
+      "Lemon Cream",
+      "Salted Cream",
+      "Ruby Swirl",
+      "Caramel Swirl",
+      "Rainbow Swirl",
+    ],
+  },
+  {
+    "Falinks": [
+      "Mega",
+    ],
+  },
+  {
+    "Pincurchin": [],
+  },
+  {
+    "Snom": [],
+  },
+  {
+    "Frosmoth": [],
+  },
+  {
+    "Stonjourner": [],
+  },
+  {
+    "Eiscue": [],
+  },
+  {
+    "Indeedee": [],
+  },
+  {
+    "Morpeko": [],
+  },
+  {
+    "Cufant": [],
+  },
+  {
+    "Copperajah": [
+      "Gigantamax",
+    ],
+  },
+  {
+    "Dracozolt": [],
+  },
+  {
+    "Arctozolt": [],
+  },
+  {
+    "Dracovish": [],
+  },
+  {
+    "Arctovish": [],
+  },
+  {
+    "Duraludon": [],
+  },
+  {
+    "Dreepy": [],
+  },
+  {
+    "Drakloak": [],
+  },
+  {
+    "Dragapult": [],
+  },
+  {
+    "Zacian": [],
+  },
+  {
+    "Zamazenta": [],
+  },
+  {
+    "Eternatus": [],
+  },
+  {
+    "Kubfu": [],
+  },
+  {
+    "Urshifu": [
+      "Single Strike",
+      "Rapid Strike",
+      "Single Strike Gigantamax",
+      "Rapid Strike Gigantamax",
+    ],
+  },
+  {
+    "Zarude": [],
+  },
+  {
+    "Regieleki": [],
+  },
+  {
+    "Regidrago": [],
+  },
+  {
+    "Glastrier": [],
+  },
+  {
+    "Spectrier": [],
+  },
+  {
+    "Calyrex": [
+      "Ice Rider",
+      "Shadow Rider",
+    ],
+  },
+  {
+    "Wyrdeer": [],
+  },
+  {
+    "Kleavor": [],
+  },
+  {
+    "Ursaluna": [],
+  },
+  {
+    "Basculegion": [],
+  },
+  {
+    "Sneasler": [],
+  },
+  {
+    "Overqwil": [],
+  },
+  {
+    "Enamorus": [
+      "Incarnate",
+      "Therian",
+    ],
+  },
+  {
+    "Sprigatito": [],
+  },
+  {
+    "Floragato": [],
+  },
+  {
+    "Meowscarada": [],
+  },
+  {
+    "Fuecoco": [],
+  },
+  {
+    "Crocalor": [],
+  },
+  {
+    "Skeledirge": [],
+  },
+  {
+    "Quaxly": [],
+  },
+  {
+    "Quaxwell": [],
+  },
+  {
+    "Quaquaval": [],
+  },
+  {
+    "Lechonk": [],
+  },
+  {
+    "Oinkologne": [],
+  },
+  {
+    "Tarountula": [],
+  },
+  {
+    "Spidops": [],
+  },
+  {
+    "Nymble": [],
+  },
+  {
+    "Lokix": [],
+  },
+  {
+    "Pawmi": [],
+  },
+  {
+    "Pawmo": [],
+  },
+  {
+    "Pawmot": [],
+  },
+  {
+    "Tandemaus": [],
+  },
+  {
+    "Maushold": [
+      "Family of Four",
+    ],
+  },
+  {
+    "Fidough": [],
+  },
+  {
+    "Dachsbun": [],
+  },
+  {
+    "Smoliv": [],
+  },
+  {
+    "Dolliv": [],
+  },
+  {
+    "Arboliva": [],
+  },
+  {
+    "Squawkabilly": [],
+  },
+  {
+    "Nacli": [],
+  },
+  {
+    "Naclstack": [],
+  },
+  {
+    "Garganacl": [],
+  },
+  {
+    "Charcadet": [],
+  },
+  {
+    "Armarouge": [],
+  },
+  {
+    "Ceruledge": [],
+  },
+  {
+    "Tadbulb": [],
+  },
+  {
+    "Bellibolt": [],
+  },
+  {
+    "Wattrel": [],
+  },
+  {
+    "Kilowattrel": [],
+  },
+  {
+    "Maschiff": [],
+  },
+  {
+    "Mabosstiff": [],
+  },
+  {
+    "Shroodle": [],
+  },
+  {
+    "Grafaiai": [],
+  },
+  {
+    "Bramblin": [],
+  },
+  {
+    "Brambleghast": [],
+  },
+  {
+    "Toedscool": [],
+  },
+  {
+    "Toedscruel": [],
+  },
+  {
+    "Klawf": [],
+  },
+  {
+    "Capsakid": [],
+  },
+  {
+    "Scovillain": [],
+  },
+  {
+    "Rellor": [],
+  },
+  {
+    "Rabsca": [],
+  },
+  {
+    "Flittle": [],
+  },
+  {
+    "Espathra": [],
+  },
+  {
+    "Tinkatink": [],
+  },
+  {
+    "Tinkatuff": [],
+  },
+  {
+    "Tinkaton": [],
+  },
+  {
+    "Wiglett": [],
+  },
+  {
+    "Wugtrio": [],
+  },
+  {
+    "Bombirdier": [],
+  },
+  {
+    "Finizen": [],
+  },
+  {
+    "Palafin": [],
+  },
+  {
+    "Varoom": [],
+  },
+  {
+    "Revavroom": [],
+  },
+  {
+    "Cyclizar": [],
+  },
+  {
+    "Orthworm": [],
+  },
+  {
+    "Glimmet": [],
+  },
+  {
+    "Glimmora": [],
+  },
+  {
+    "Greavard": [],
+  },
+  {
+    "Houndstone": [],
+  },
+  {
+    "Flamigo": [],
+  },
+  {
+    "Cetoddle": [],
+  },
+  {
+    "Cetitan": [],
+  },
+  {
+    "Veluza": [],
+  },
+  {
+    "Dondozo": [],
+  },
+  {
+    "Tatsugiri": [],
+  },
+  {
+    "Annihilape": [],
+  },
+  {
+    "Clodsire": [],
+  },
+  {
+    "Farigiraf": [],
+  },
+  {
+    "Dudunsparce": [
+      "Three Segment",
+    ],
+  },
+  {
+    "Kingambit": [],
+  },
+  {
+    "Great Tusk": [],
+  },
+  {
+    "Scream Tail": [],
+  },
+  {
+    "Brute Bonnet": [],
+  },
+  {
+    "Flutter Mane": [],
+  },
+  {
+    "Slither Wing": [],
+  },
+  {
+    "Sandy Shocks": [],
+  },
+  {
+    "Iron Treads": [],
+  },
+  {
+    "Iron Bundle": [],
+  },
+  {
+    "Iron Hands": [],
+  },
+  {
+    "Iron Jugulis": [],
+  },
+  {
+    "Iron Moth": [],
+  },
+  {
+    "Iron Thorns": [],
+  },
+  {
+    "Frigibax": [],
+  },
+  {
+    "Arctibax": [],
+  },
+  {
+    "Baxcalibur": [],
+  },
+  {
+    "Gimmighoul": [
+      "Roaming",
+    ],
+  },
+  {
+    "Gholdengo": [],
+  },
+  {
+    "Wo-Chien": [],
+  },
+  {
+    "Chien-Pao": [],
+  },
+  {
+    "Ting-Lu": [],
+  },
+  {
+    "Chi-Yu": [],
+  },
+  {
+    "Roaring Moon": [],
+  },
+  {
+    "Iron Valiant": [],
+  },
+  {
+    "Koraidon": [],
+  },
+  {
+    "Miraidon": [],
+  },
+  {
+    "Walking Wake": [],
+  },
+  {
+    "Iron Leaves": [],
+  },
+  {
+    "Dipplin": [],
+  },
+  {
+    "Poltchageist": [],
+  },
+  {
+    "Sinistcha": [],
+  },
+  {
+    "Okidogi": [],
+  },
+  {
+    "Munkidori": [],
+  },
+  {
+    "Fezandipiti": [],
+  },
+  {
+    "Ogerpon": [
+      "Teal Mask",
+      "Wellspring",
+      "Heartflame",
+      "Cornerstone",
+    ],
+  },
+  {
+    "Archaludon": [],
+  },
+  {
+    "Hydrapple": [],
+  },
+  {
+    "Gouging Fire": [],
+  },
+  {
+    "Raging Bolt": [],
+  },
+  {
+    "Iron Boulder": [],
+  },
+  {
+    "Iron Crown": [],
+  },
+  {
+    "Terapagos": [
+      "Terastal",
+    ],
+  },
+  {
+    "Pecharunt": [],
   },
 ]
 `;

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -380,10 +380,12 @@ describe(matchNatureToToxtricityForme.name, () => {
 });
 
 describe(getAdditionalFormes.name, () => {
-    const subject = listOfPokemon.map((species) => ({
-        [species]: getAdditionalFormes(species),
-    }));
-    expect(subject).toMatchSnapshot();
+    it("matches snapshot for all species", () => {
+        const subject = listOfPokemon.map((species) => ({
+            [species]: getAdditionalFormes(species),
+        }));
+        expect(subject).toMatchSnapshot();
+    });
 });
 
 describe.skip(getEvolutionLine.name, () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -63,6 +63,15 @@ export default defineConfig({
         alias: {
             // Prefer Node built-ins over npm packages with same name
             path: "node:path",
+            // Ensure Vitest can resolve React's JSX runtime files
+            "react/jsx-runtime": path.resolve(
+                __dirname,
+                "node_modules/react/jsx-runtime.js",
+            ),
+            "react/jsx-dev-runtime": path.resolve(
+                __dirname,
+                "node_modules/react/jsx-dev-runtime.js",
+            ),
         },
         dedupe: ["react", "react-dom"],
     },
@@ -97,10 +106,16 @@ export default defineConfig({
     optimizeDeps: {
         include: ["react", "react-dom"],
     },
+    ssr: {
+        noExternal: ["react-dnd", "react-dnd-html5-backend"],
+    },
     test: {
         globals: true,
         environment: "jsdom",
         setupFiles: ["./setupTests.ts"],
+        deps: {
+            inline: ["react-dnd", "react-dnd-html5-backend"],
+        },
         coverage: {
             provider: "v8",
             reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary
- ensure Vitest resolves React JSX runtime imports by aliasing to concrete files and inlining React DnD dependencies for SSR
- update error boundary test to assert fallback rendering without class lifecycle spying
- wrap additional formes snapshot in a named test case and refresh the snapshot

## Testing
- `npx vitest run src/components/Common/Shared/__tests__/Autocomplete.test.tsx src/components/Common/Shared/__tests__/ErrorBoundary.test.tsx --coverage=false`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a132547c8832781f4bedbc7b79623)