### PR TITLE
Restore Pokémon badge display on team panels

### DIFF
--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -20,7 +20,7 @@ import { State } from "state";
 import { css, cx } from "emotion";
 import { PokemonIcon } from "components/Pokemon/PokemonIcon/PokemonIcon";
 import { getMetLocationString } from "./getMetLocationString";
-// import { CheckpointsDisplay } from 'components/Features/Result/Result';
+import { CheckpointsDisplay } from "components/Features/Result/TrainerResult";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { PokemonItem } from "./PokemonItem";
 import { PokemonPokeball } from "./PokemonPokeball";
@@ -214,12 +214,12 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                                 className="flex flex-wrap pokemon-checkpoints"
                                 style={{ maxWidth: "14rem" }}
                             >
-                                {/* <CheckpointsDisplay
-                  className="pokemon-checkpoint"
-                  game={game}
-                  clearedCheckpoints={pokemon.checkpoints}
-                  style={style}
-                /> */}
+                                <CheckpointsDisplay
+                                    className="pokemon-checkpoint"
+                                    game={game}
+                                    clearedCheckpoints={pokemon.checkpoints}
+                                    style={style}
+                                />
                             </div>
                         )}
                         {style.displayExtraData && pokemon.extraData ? (

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon2.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon2.tsx
@@ -1,7 +1,7 @@
 import { Pokemon } from "models";
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
-import { useSelector } from "react-redux";
+import { Provider, useSelector, useStore } from "react-redux";
 import { State } from "state";
 import {
     formatBallText,
@@ -11,7 +11,7 @@ import {
     typeToColor,
 } from "utils";
 import { css } from "emotion";
-import * as Mustache from "mustache";
+import Mustache from "mustache";
 import { ErrorBoundary, PokemonIconPlain } from "components";
 import { uniq } from "ramda";
 import { MovesBase } from "./Moves";
@@ -20,6 +20,7 @@ import { Result } from "components/Features/Result/Result";
 import { linkedPokemonSelector } from "selectors";
 import { PokemonItem } from "./PokemonItem";
 import { PokemonPokeball } from "./PokemonPokeball";
+import { CheckpointsDisplay } from "components/Features/Result/TrainerResult";
 
 export interface TeamPokemonProps {
     pokemon: Pokemon;
@@ -56,12 +57,12 @@ const TeamCheckpointsDisplay = ({ game, pokemon, style }) => {
     return (
         <ErrorBoundary>
             <div className="flex flex-wrap" style={{ maxWidth: "14rem" }}>
-                {/* <CheckpointsDisplay
-          className="pokemon-checkpoint"
-          game={game}
-          clearedCheckpoints={pokemon.checkpoints}
-          style={style}
-        /> */}
+                <CheckpointsDisplay
+                    className="pokemon-checkpoint"
+                    game={game}
+                    clearedCheckpoints={pokemon.checkpoints}
+                    style={style}
+                />
             </div>
         </ErrorBoundary>
     );
@@ -87,6 +88,7 @@ export function TeamPokemon({
     const customTypes = useSelector<State, State["customTypes"]>(
         (state) => state.customTypes,
     );
+    const store = useStore();
 
     const teamHTML = style.customTeamHTML;
 
@@ -179,7 +181,15 @@ export function TeamPokemon({
             />,
         ),
         icon: ReactDOMServer.renderToString(pokemonIcon),
-        checkpoints: ReactDOMServer.renderToString(<div />),
+        checkpoints: ReactDOMServer.renderToString(
+            <Provider store={store}>
+                <TeamCheckpointsDisplay
+                    game={game}
+                    pokemon={pokemon}
+                    style={style}
+                />
+            </Provider>,
+        ),
         genderSymbol: ReactDOMServer.renderToString(
             <GenderElementReact gender={pokemon?.gender} />,
         ),


### PR DESCRIPTION
## Summary
- re-enable checkpoint badge display on Pokémon info cards
- include checkpoint rendering in custom team templates with proper context and Mustache import

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a59dea7248327af9182d32f819e1f)