### PR TITLE
Fix layout shift while dragging Pokemon icons

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,13 +62,14 @@ void injectGlobal`
     body {
         background: #fff;
         font-family: 'Arial';
+        overflow-x: hidden;
     }
 
     .app {
         display: flex;
         height: 100vh;
         min-width: 100%;
-        overflow-y: hidden;
+        overflow: hidden;
     }
 
     .opacity-medium {


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on the page and app container to avoid horizontal shifts during drag and drop interactions

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd3b59fd0832792210474a938f3b6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents horizontal scrolling and hides overflow in `.app` to reduce drag-drop layout shifts.
> 
> - **Frontend – Global styles (`src/index.tsx`)**:
>   - Add `overflow-x: hidden` to `body`.
>   - Change `.app` from `overflow-y: hidden` to `overflow: hidden` to suppress overflow on both axes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61b66fe9cc42c84a46d3fa58d420caff4c24b3d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->