### PR TITLE
Fix Corviknight type order in matchSpeciesToTypes

### DIFF
--- a/src/utils/formatters/matchSpeciesToTypes.ts
+++ b/src/utils/formatters/matchSpeciesToTypes.ts
@@ -1630,8 +1630,9 @@ export const matchSpeciesToTypes = (
             return [Types.Water, Types.Poison];
         case "Skarmory":
         case "Celesteela":
-        case "Corviknight":
             return [Types.Steel, Types.Flying];
+        case "Corviknight":
+            return [Types.Flying, Types.Steel];
 
         case "Larvitar":
         case "Pupitar":


### PR DESCRIPTION
### Motivation

- Ensure the species-to-type mapping reflects the correct primary and secondary types for Corviknight in `matchSpeciesToTypes`.  

### Description

- Change the `Corviknight` case in `src/utils/formatters/matchSpeciesToTypes.ts` to return `[Types.Flying, Types.Steel]` instead of `[Types.Steel, Types.Flying]`.  
- Separate `Corviknight` from the grouped `Skarmory`/`Celesteela` case so it can have a distinct type order.  

### Testing

- Ran the project's unit tests and they completed successfully.  
- Ran the TypeScript type check and linter and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f59015c28883278587cb054133127f)