### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Nuzlocke Generator
+
+A React + Redux web app for tracking Pokémon Nuzlocke challenge runs. All user data is stored client-side (localStorage + IndexedDB). No database required.
+
+## Cursor Cloud specific instructions
+
+### Node version
+
+This project requires **Node.js ^24** and **npm >=11**. The environment uses nvm with Node 24 set as the default alias.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Dev server | `npm run dev` (Vite on `localhost:8080`) |
+| Lint | `npm run lint` |
+| Unit tests | `npm run test:run` (vitest) |
+| Type check | `npm run typecheck` |
+| Build | `npm run build` |
+| E2E tests | `npx playwright install --with-deps chromium && npm run test:e2e` |
+
+### Dev server notes
+
+- `npm run dev` starts Vite with HMR on port 8080.
+- The Express server (`npm run serve:node`) is only needed for the `/report` and `/release` API endpoints (GitHub bug reporter + release notes). The Vite dev server is sufficient for frontend development.
+- No `.env` file is required for core functionality; optional env vars (`GH_ACCESS_TOKEN`, `VITE_CORS_ANYWHERE_URL`) enable bug reporting and sprites mode.
+
+### Testing notes
+
+- Unit tests use vitest with jsdom environment. Run `npm run test:run` for a single pass.
+- E2E tests require Playwright with Chromium. Install browsers first: `npx playwright install --with-deps chromium`.
+- Lint exits 0 with warnings only (no errors) on a clean checkout.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions to help future agents set up and work with this codebase efficiently.

## What's included

- Node version requirements (Node 24+, npm 11+)
- Quick-reference table of key commands (dev, lint, test, build, e2e)
- Dev server notes (Vite on port 8080, no `.env` required for core functionality)
- Testing notes (vitest + playwright setup)

## Environment verification

All core dev tasks verified working:

- `npm install` — installs 1355 packages cleanly
- `npm run lint` — exits 0 (312 warnings, 0 errors)
- `npm run test:run` — 521 tests pass (6 skipped)
- `npm run build` — builds in ~6s
- `npm run dev` — Vite HMR server on localhost:8080

## Demo

[demo_nuzlocke_add_pokemon.mp4](https://cursor.com/agents/bc-d6d4094c-c6bf-44b5-9141-ec85a123ed01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_nuzlocke_add_pokemon.mp4)

App running locally with Pokémon added to a Nuzlocke run (Pikachu "Sparky" lv.25, Charmander "Blaze" lv.15).

[App loaded](https://cursor.com/agents/bc-d6d4094c-c6bf-44b5-9141-ec85a123ed01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_loaded.webp)
[Pokemon added](https://cursor.com/agents/bc-d6d4094c-c6bf-44b5-9141-ec85a123ed01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpokemon_added.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6d4094c-c6bf-44b5-9141-ec85a123ed01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6d4094c-c6bf-44b5-9141-ec85a123ed01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

