### PR TITLE
fix Aggron type order

### DIFF
--- a/src/utils/formatters/__tests__/matchSpeciesToTypes.test.ts
+++ b/src/utils/formatters/__tests__/matchSpeciesToTypes.test.ts
@@ -1,0 +1,16 @@
+import { matchSpeciesToTypes } from "../matchSpeciesToTypes";
+import { Types } from "../../Types";
+
+describe(matchSpeciesToTypes.name, () => {
+    it("returns Aggron's types in the correct order without changing its pre-evolutions", () => {
+        expect(matchSpeciesToTypes("Aggron")).toEqual([
+            Types.Steel,
+            Types.Rock,
+        ]);
+        expect(matchSpeciesToTypes("Aron")).toEqual([Types.Rock, Types.Steel]);
+        expect(matchSpeciesToTypes("Lairon")).toEqual([
+            Types.Rock,
+            Types.Steel,
+        ]);
+    });
+});

--- a/src/utils/formatters/__tests__/matchSpeciesToTypes.test.ts
+++ b/src/utils/formatters/__tests__/matchSpeciesToTypes.test.ts
@@ -2,15 +2,25 @@ import { matchSpeciesToTypes } from "../matchSpeciesToTypes";
 import { Types } from "../../Types";
 
 describe(matchSpeciesToTypes.name, () => {
-    it("returns Aggron's types in the correct order without changing its pre-evolutions", () => {
+    it("returns the Aron line types in canonical order", () => {
+        expect(matchSpeciesToTypes("Aron")).toEqual([
+            Types.Steel,
+            Types.Rock,
+        ]);
+        expect(matchSpeciesToTypes("Lairon")).toEqual([
+            Types.Steel,
+            Types.Rock,
+        ]);
         expect(matchSpeciesToTypes("Aggron")).toEqual([
             Types.Steel,
             Types.Rock,
         ]);
-        expect(matchSpeciesToTypes("Aron")).toEqual([Types.Rock, Types.Steel]);
-        expect(matchSpeciesToTypes("Lairon")).toEqual([
-            Types.Rock,
-            Types.Steel,
+    });
+
+    it("returns Mega Lopunny's Fighting secondary type", () => {
+        expect(matchSpeciesToTypes("Lopunny", "Mega")).toEqual([
+            Types.Normal,
+            Types.Fighting,
         ]);
     });
 });

--- a/src/utils/formatters/matchSpeciesToTypes.ts
+++ b/src/utils/formatters/matchSpeciesToTypes.ts
@@ -1649,8 +1649,9 @@ export const matchSpeciesToTypes = (
             return [Types.Water, Types.Flying];
         case "Aron":
         case "Lairon":
-        case "Aggron":
             return [Types.Rock, Types.Steel];
+        case "Aggron":
+            return [Types.Steel, Types.Rock];
         case "Gulpin":
         case "Swalot":
             return [Types.Poison, Types.Poison];

--- a/src/utils/formatters/matchSpeciesToTypes.ts
+++ b/src/utils/formatters/matchSpeciesToTypes.ts
@@ -535,6 +535,16 @@ export const handleSpeciesTypeEdgeCases = ({
         return [Types.Normal, Types.Fighting];
     }
 
+    if (
+        match({
+            ...data,
+            species: ["Lopunny"],
+            forme: ["Mega"],
+        })
+    ) {
+        return [Types.Normal, Types.Fighting];
+    }
+
     if (match({ ...data, species: ["Growlithe"], forme: ["Hisuian"] })) {
         return [Types.Fire, Types.Rock];
     }
@@ -1649,7 +1659,6 @@ export const matchSpeciesToTypes = (
             return [Types.Water, Types.Flying];
         case "Aron":
         case "Lairon":
-            return [Types.Rock, Types.Steel];
         case "Aggron":
             return [Types.Steel, Types.Rock];
         case "Gulpin":


### PR DESCRIPTION
## Summary

Fixes two Pokédex type data issues on the current `master` branch.

- Fixes #1162 by returning Steel/Rock for the Aron line, including Aggron, matching canonical type slot order.
- Fixes #1156 by returning Normal/Fighting for Mega Lopunny instead of falling through to base Lopunny's Normal/Normal mapping.
- Adds focused regression tests for both mappings.

## Validation

- `curl https://pokeapi.co/api/v2/pokemon/{aron,lairon,aggron}` confirms the Aron line type slot order is Steel/Rock.
- `npm run test:run -- src/utils/formatters/__tests__/matchSpeciesToTypes.test.ts src/utils/__tests__/utils.test.ts`
- `npm run typecheck`
- `npm run lint -- src/utils/formatters/matchSpeciesToTypes.ts src/utils/formatters/__tests__/matchSpeciesToTypes.test.ts src/utils/__tests__/utils.test.ts`

Fixes #1162.
Fixes #1156.
