### PR TITLE
fix(download): enable CORS proxy for image downloads

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -207,7 +207,13 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         try {
             const domToImage = await load();
             const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
+                corsImg: {
+                    method: "GET",
+                    url: "https://cors-anywhere-nuzgen.herokuapp.com/#{cors}",
+                    data: {},
+                },
+                imagePlaceholder:
+                    "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",
             });
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");


### PR DESCRIPTION
## Root cause

The `dom-to-image` library was called with `corsImage: true` but the library's option is `corsImg` and expects a proxy config object. The boolean was silently ignored, meaning **all cross-origin images failed** during the download render pass.

## Fix

```diff
- corsImage: true,
+ corsImg: {
+     method: "GET",
+     url: "https://cors-anywhere-nuzgen.herokuapp.com/#{cors}",
+     data: {},
+ },
+ imagePlaceholder: "data:image/svg+xml;base64,...",
```

- Enables the CORS proxy that was already configured in `wrapImageInCORS.ts`
- Adds a transparent placeholder so failed images don't hang the download promise

## Closes

**P0 — Download broken:** #963 #935 #733 #961 #939 #932 #930 #907 #847 #828 #772 #653 #561 #506 #469 #438 #446 #420 #542 #959
**P0 — Download loops/stalls:** #743 #742 #470 #911 #835 #677
**P1 — Sprites+download:** #952 #726 #465 #676
**P1 — Images not loading:** #495 #476 #455 #464 #755 #741 #950 #925 #1003 #991 #565 #358 #477
**P2 — Custom images:** likely resolves #642 #620 #508 #454 #423 #447