### PR TITLE
fix(download): enable image CORS proxy

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -43,6 +43,7 @@ import { resultSelector } from "selectors";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { normalizeSpeciesName } from "utils/getters/normalizeSpeciesName";
 import { Select } from "@blueprintjs/select";
+import { getDownloadImageOptions } from "./downloadImageOptions";
 
 async function load() {
     const resource = await import("@emmaramirez/dom-to-image");
@@ -206,9 +207,10 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         this.setState({ isDownloading: true });
         try {
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDownloadImageOptions(),
+            );
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -23,6 +23,10 @@ import { TrainerResult } from "./TrainerResult";
 import { getContrastColor } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
+import {
+    DownloadImageOptions,
+    getDownloadImageOptions,
+} from "./downloadImageOptions";
 
 import { v4 as uuid } from "uuid";
 
@@ -34,7 +38,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: DownloadImageOptions,
     ) => Promise<string>;
 };
 
@@ -89,9 +93,10 @@ const toImage =
         try {
             setDS(DownloadStatus.active);
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDownloadImageOptions(),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/__tests__/downloadImageOptions.test.ts
+++ b/src/components/Features/Result/__tests__/downloadImageOptions.test.ts
@@ -1,0 +1,27 @@
+import { getDownloadImageOptions } from "../downloadImageOptions";
+
+describe("getDownloadImageOptions", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it("enables the dom-to-image CORS proxy option", () => {
+        expect(getDownloadImageOptions()).toEqual({
+            corsImg: {
+                method: "GET",
+                url: "https://cors-anywhere-nuzgen.herokuapp.com/#{cors}",
+                data: {},
+            },
+            imagePlaceholder:
+                "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",
+        });
+    });
+
+    it("uses the configured CORS proxy URL without duplicating slashes", () => {
+        vi.stubEnv("VITE_CORS_ANYWHERE_URL", "https://cors.example/proxy/");
+
+        expect(getDownloadImageOptions().corsImg.url).toBe(
+            "https://cors.example/proxy/#{cors}",
+        );
+    });
+});

--- a/src/components/Features/Result/downloadImageOptions.ts
+++ b/src/components/Features/Result/downloadImageOptions.ts
@@ -1,0 +1,26 @@
+const getCorsProxyUrl = () =>
+    import.meta.env.VITE_CORS_ANYWHERE_URL ??
+    "https://cors-anywhere-nuzgen.herokuapp.com";
+
+export const transparentImagePlaceholder =
+    "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==";
+
+export type DownloadImageOptions = {
+    corsImg: {
+        method: "GET";
+        url: string;
+        data: Record<string, never>;
+    };
+    imagePlaceholder: string;
+};
+
+export function getDownloadImageOptions(): DownloadImageOptions {
+    return {
+        corsImg: {
+            method: "GET",
+            url: `${getCorsProxyUrl().replace(/\/$/, "")}/#{cors}`,
+            data: {},
+        },
+        imagePlaceholder: transparentImagePlaceholder,
+    };
+}


### PR DESCRIPTION
## Summary

Fixes ART-10 by making result image downloads activate the CORS proxy option that `@emmaramirez/dom-to-image` actually supports.

The old download calls passed `corsImage: true`, but the library reads `corsImg` from its options. Because that misspelled boolean was ignored, cross-origin sprites and custom images could still fail or taint the canvas during export even though the app already had proxy configuration available.

## Changes

- Added a shared `getDownloadImageOptions()` helper for result image exports.
- Updated both `Result` and `Result2` download paths to pass a `corsImg` proxy config instead of `corsImage`.
- Reused `VITE_CORS_ANYWHERE_URL` when configured, falling back to the existing Heroku CORS proxy.
- Added a transparent `imagePlaceholder` so individual failed image fetches do not block the full export.
- Added unit coverage for the exact `corsImg` option shape and proxy URL slash normalization.

## Validation

Local validation with project-required Node `24.11.0` / npm `11.6.2`:

- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (51 passed, 1 skipped; 585 passed, 6 skipped)
- `npm run build`

GitHub checks are also passing on the draft PR.
