### PR TITLE
fix(download): add image fallback for result exports

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -43,6 +43,7 @@ import { resultSelector } from "selectors";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { normalizeSpeciesName } from "utils/getters/normalizeSpeciesName";
 import { Select } from "@blueprintjs/select";
+import { getDomToImageDownloadOptions } from "./downloadImageOptions";
 
 async function load() {
     const resource = await import("@emmaramirez/dom-to-image");
@@ -206,9 +207,10 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         this.setState({ isDownloading: true });
         try {
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDomToImageDownloadOptions(),
+            );
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -23,6 +23,10 @@ import { TrainerResult } from "./TrainerResult";
 import { getContrastColor } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
+import {
+    DomToImageDownloadOptions,
+    getDomToImageDownloadOptions,
+} from "./downloadImageOptions";
 
 import { v4 as uuid } from "uuid";
 
@@ -34,7 +38,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: DomToImageDownloadOptions,
     ) => Promise<string>;
 };
 
@@ -89,9 +93,10 @@ const toImage =
         try {
             setDS(DownloadStatus.active);
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDomToImageDownloadOptions(),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { ResultBase, BackspriteMontage } from "../Result";
 import { styleDefaults, generateEmptyPokemon } from "utils";
@@ -9,6 +9,24 @@ type ResultBaseProps = React.ComponentProps<typeof ResultBase>;
 type PokemonSpeciesProps = { species: string };
 type PokemonProp = { pokemon: Pokemon };
 type ChildrenProps = { children?: React.ReactNode };
+type TopBarProps = ChildrenProps & {
+    isDownloading?: boolean;
+    onClickDownload?: () => void;
+};
+
+const mocks = vi.hoisted(() => ({
+    toPng: vi.fn(),
+}));
+
+vi.mock("@emmaramirez/dom-to-image", () => ({
+    domToImage: {
+        toPng: mocks.toPng,
+    },
+}));
+
+vi.mock("uuid", () => ({
+    v4: () => "test-download",
+}));
 
 vi.mock("components/Pokemon/TeamPokemon/TeamPokemon", () => ({
     TeamPokemon: ({ pokemon }: PokemonProp) => (
@@ -39,8 +57,17 @@ vi.mock("components/Features/Result/TrainerResult", () => ({
 }));
 
 vi.mock("components/Layout/TopBar/TopBar", () => ({
-    TopBar: ({ children }: { children?: React.ReactNode }) => (
-        <div data-testid="top-bar">{children}</div>
+    TopBar: ({ children, isDownloading, onClickDownload }: TopBarProps) => (
+        <div data-testid="top-bar">
+            <button
+                data-testid="download-image-button"
+                disabled={isDownloading}
+                onClick={onClickDownload}
+            >
+                Download Image
+            </button>
+            {children}
+        </div>
     ),
 }));
 
@@ -94,6 +121,14 @@ const createPokemon = () => [
 ];
 
 describe("<ResultBase />", () => {
+    beforeEach(() => {
+        mocks.toPng.mockResolvedValue("data:image/png;base64,test");
+    });
+
+    afterEach(() => {
+        mocks.toPng.mockReset();
+    });
+
     it("renders team and status sections with rules", () => {
         render(
             <ResultBase
@@ -123,6 +158,54 @@ describe("<ResultBase />", () => {
         expect(screen.getByText("Boxed")).toBeTruthy();
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
+    });
+
+    it("passes CORS proxy and placeholder fallback options to dom-to-image downloads", async () => {
+        const clickSpy = vi
+            .spyOn(HTMLAnchorElement.prototype, "click")
+            .mockImplementation(() => undefined);
+
+        render(
+            <ResultBase
+                pokemon={createPokemon()}
+                game={{ name: "Red", customName: "" }}
+                trainer={{ notes: "Remember to heal", badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    displayRules: true,
+                    displayRulesLocation: "top",
+                    trainerSectionOrientation: "horizontal",
+                }}
+                rules={["Rule 1", "Rule 2"]}
+                customTypes={[]}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId("download-image-button"));
+
+        await waitFor(() => expect(mocks.toPng).toHaveBeenCalledTimes(1));
+
+        const [, options] = mocks.toPng.mock.calls[0];
+        expect(options).toEqual({
+            corsImg: {
+                method: "GET",
+                url: "https://cors-anywhere-nuzgen.herokuapp.com/#{cors}",
+                data: {},
+            },
+            imagePlaceholder:
+                "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",
+        });
+        expect(options).not.toHaveProperty("corsImage");
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+
+        clickSpy.mockRestore();
     });
 });
 

--- a/src/components/Features/Result/downloadImageOptions.ts
+++ b/src/components/Features/Result/downloadImageOptions.ts
@@ -1,0 +1,29 @@
+const DEFAULT_CORS_PROXY_BASE_URL =
+    "https://cors-anywhere-nuzgen.herokuapp.com";
+
+export const imagePlaceholder =
+    "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==";
+
+export type DomToImageDownloadOptions = {
+    corsImg: {
+        method: "GET";
+        url: string;
+        data: Record<string, never>;
+    };
+    imagePlaceholder: string;
+};
+
+export function getDomToImageDownloadOptions(): DomToImageDownloadOptions {
+    const proxyBase = (
+        import.meta.env.VITE_CORS_ANYWHERE_URL ?? DEFAULT_CORS_PROXY_BASE_URL
+    ).replace(/\/$/, "");
+
+    return {
+        corsImg: {
+            method: "GET",
+            url: `${proxyBase}/#{cors}`,
+            data: {},
+        },
+        imagePlaceholder,
+    };
+}


### PR DESCRIPTION
## Summary

Fixes the result image export path so failed or cross-origin images do not leave the download button stuck in the active state forever.

The download flow was still passing `corsImage: true` to `@emmaramirez/dom-to-image`, but the forked library reads the option as `corsImg` and only uses image fallbacks when `imagePlaceholder` is provided. Because the typo was silently ignored, failed remote images could break the render pass and users would see an endless "Downloading" state instead of getting a PNG or a handled error.

This PR adds one shared download-options helper for both Result views. It enables the existing CORS proxy shape used by the app (`VITE_CORS_ANYWHERE_URL` when configured, otherwise the nuzgen cors-anywhere proxy) and supplies a transparent SVG placeholder for failed image fetches. The Result v2 download path now uses the same typed options, so future changes cannot keep using the old `corsImage` spelling there.

Linear: ART-11

Closes #743, #742, #470, #911, #835, #677.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 24 && npm run typecheck`
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run lint`
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run test:run`
- `source ~/.nvm/nvm.sh && nvm use 24 && npm run build`

## Remote checks

- `check-slug-size` passed
- `validate` passed
- `Vercel` passed
- `Vercel Preview Comments` passed
