### PR TITLE
[codex] fix clipped result image downloads

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -43,6 +43,7 @@ import { resultSelector } from "selectors";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { normalizeSpeciesName } from "utils/getters/normalizeSpeciesName";
 import { Select } from "@blueprintjs/select";
+import { getResultImageDownloadOptions } from "./downloadImage";
 
 async function load() {
     const resource = await import("@emmaramirez/dom-to-image");
@@ -205,10 +206,14 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         const resultNode = this.resultRef.current;
         this.setState({ isDownloading: true });
         try {
+            if (!resultNode) {
+                throw new Error("Result node is not available for download.");
+            }
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getResultImageDownloadOptions(resultNode),
+            );
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -23,6 +23,10 @@ import { TrainerResult } from "./TrainerResult";
 import { getContrastColor } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
+import {
+    DomToImageDownloadOptions,
+    getResultImageDownloadOptions,
+} from "./downloadImage";
 
 import { v4 as uuid } from "uuid";
 
@@ -34,7 +38,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: DomToImageDownloadOptions,
     ) => Promise<string>;
 };
 
@@ -89,9 +93,10 @@ const toImage =
         try {
             setDS(DownloadStatus.active);
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getResultImageDownloadOptions(resultNode),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/__tests__/downloadImage.test.ts
+++ b/src/components/Features/Result/__tests__/downloadImage.test.ts
@@ -1,0 +1,56 @@
+import { getResultImageDownloadOptions } from "../downloadImage";
+
+const setReadOnlyNumber = (
+    node: HTMLElement,
+    property: keyof HTMLElement,
+    value: number,
+) => {
+    Object.defineProperty(node, property, {
+        configurable: true,
+        value,
+    });
+};
+
+describe("getResultImageDownloadOptions", () => {
+    it("exports the full scrollable result instead of the clipped viewport", () => {
+        const node = document.createElement("div");
+        setReadOnlyNumber(node, "clientWidth", 800);
+        setReadOnlyNumber(node, "offsetWidth", 800);
+        setReadOnlyNumber(node, "scrollWidth", 1200);
+        setReadOnlyNumber(node, "clientHeight", 600);
+        setReadOnlyNumber(node, "offsetHeight", 600);
+        setReadOnlyNumber(node, "scrollHeight", 1400);
+        node.getBoundingClientRect = () =>
+            ({
+                width: 800,
+                height: 600,
+            }) as DOMRect;
+
+        const options = getResultImageDownloadOptions(node);
+
+        expect(options.width).toBe(1200);
+        expect(options.height).toBe(1400);
+        expect(options.style.width).toBe("1200px");
+        expect(options.style.height).toBe("1400px");
+        expect(options.style.minHeight).toBe("1400px");
+        expect(options.style.overflow).toBe("visible");
+    });
+
+    it("removes preview-only positioning and transforms from the cloned image", () => {
+        const node = document.createElement("div");
+        setReadOnlyNumber(node, "clientWidth", 300);
+        setReadOnlyNumber(node, "offsetWidth", 300);
+        setReadOnlyNumber(node, "scrollWidth", 300);
+        setReadOnlyNumber(node, "clientHeight", 200);
+        setReadOnlyNumber(node, "offsetHeight", 200);
+        setReadOnlyNumber(node, "scrollHeight", 200);
+
+        const options = getResultImageDownloadOptions(node);
+
+        expect(options.style.transform).toBe("none");
+        expect(options.style.position).toBe("relative");
+        expect(options.style.left).toBe("0");
+        expect(options.style.top).toBe("0");
+        expect(options.style.margin).toBe("0");
+    });
+});

--- a/src/components/Features/Result/downloadImage.ts
+++ b/src/components/Features/Result/downloadImage.ts
@@ -1,0 +1,64 @@
+export type DomToImageDownloadOptions = {
+    corsImage: boolean;
+    width: number;
+    height: number;
+    style: Record<string, string>;
+};
+
+const positiveCeil = (value: number | undefined) => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+    return Math.max(0, Math.ceil(value));
+};
+
+const getElementWidth = (node: HTMLElement) => {
+    const rect = node.getBoundingClientRect();
+    return Math.max(
+        1,
+        positiveCeil(node.scrollWidth),
+        positiveCeil(node.offsetWidth),
+        positiveCeil(node.clientWidth),
+        positiveCeil(rect.width),
+    );
+};
+
+const getElementHeight = (node: HTMLElement) => {
+    const rect = node.getBoundingClientRect();
+    return Math.max(
+        1,
+        positiveCeil(node.scrollHeight),
+        positiveCeil(node.offsetHeight),
+        positiveCeil(node.clientHeight),
+        positiveCeil(rect.height),
+    );
+};
+
+export const getResultImageDownloadOptions = (
+    node: HTMLElement,
+): DomToImageDownloadOptions => {
+    const width = getElementWidth(node);
+    const height = getElementHeight(node);
+
+    return {
+        corsImage: true,
+        width,
+        height,
+        style: {
+            bottom: "auto",
+            height: `${height}px`,
+            left: "0",
+            margin: "0",
+            maxHeight: "none",
+            maxWidth: "none",
+            minHeight: `${height}px`,
+            overflow: "visible",
+            overflowX: "visible",
+            overflowY: "visible",
+            position: "relative",
+            right: "auto",
+            top: "0",
+            transform: "none",
+            transformOrigin: "0 0",
+            width: `${width}px`,
+        },
+    };
+};


### PR DESCRIPTION
## Summary

Fixes result image downloads that could be clipped on the left or bottom when the preview/result node had scrollable overflow, fixed/mobile positioning, or preview transforms.

## Root cause

`dom-to-image` sized the canvas from the result node, but the cloned root kept the preview CSS (`height`, `overflow: hidden`, transforms, and mobile/fixed positioning). That meant the canvas could be large enough while the cloned content itself was still clipped before being drawn.

## Changes

- Added a shared result download options helper that sizes exports from the full scroll dimensions.
- Forces the cloned export root to be untransformed, relatively positioned, marginless, and overflow-visible during image generation.
- Reused the same helper in both Result and Result v2 download flows.
- Added unit coverage for full scroll sizing and preview transform/position reset.

## Validation

- `PATH=/Users/emma/.nvm/versions/node/v24.11.0/bin:$PATH npm run typecheck`
- `PATH=/Users/emma/.nvm/versions/node/v24.11.0/bin:$PATH npm run lint`
- `PATH=/Users/emma/.nvm/versions/node/v24.11.0/bin:$PATH npm run test:run`
- `PATH=/Users/emma/.nvm/versions/node/v24.11.0/bin:$PATH npm run build`
- Browser-level synthetic `dom-to-image` checks verified bottom overflow content renders after the export style override and transformed/fixed left-edge content no longer exports transparent/clipped.

Fixes #504.