### PR TITLE
Fix proxied image loading for downloads

### DIFF
--- a/imageProxy.js
+++ b/imageProxy.js
@@ -1,0 +1,129 @@
+import net from "node:net";
+
+export const IMAGE_PROXY_ROUTE = "/image-proxy";
+export const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
+
+const IMAGE_PROXY_TIMEOUT_MS = 30000;
+
+export class ImageProxyError extends Error {
+    constructor(statusCode, message) {
+        super(message);
+        this.name = "ImageProxyError";
+        this.statusCode = statusCode;
+    }
+}
+
+const isPrivateIPv4 = (hostname) => {
+    const parts = hostname.split(".").map((part) => Number(part));
+    const [first, second] = parts;
+
+    return (
+        first === 0 ||
+        first === 10 ||
+        first === 127 ||
+        (first === 169 && second === 254) ||
+        (first === 172 && second >= 16 && second <= 31) ||
+        (first === 192 && second === 168) ||
+        (first === 100 && second >= 64 && second <= 127)
+    );
+};
+
+const isPrivateIPv6 = (hostname) => {
+    const normalized = hostname.toLowerCase();
+
+    return (
+        normalized === "::1" ||
+        normalized.startsWith("fc") ||
+        normalized.startsWith("fd") ||
+        normalized.startsWith("fe80:")
+    );
+};
+
+export function validateImageProxyUrl(rawUrl) {
+    if (!rawUrl || typeof rawUrl !== "string") {
+        throw new ImageProxyError(400, "Missing image URL.");
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        throw new ImageProxyError(400, "Invalid image URL.");
+    }
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new ImageProxyError(400, "Image URL must use HTTP or HTTPS.");
+    }
+
+    const hostname = parsed.hostname.replace(/^\[(.*)\]$/, "$1").toLowerCase();
+    const ipVersion = net.isIP(hostname);
+
+    if (
+        hostname === "localhost" ||
+        hostname.endsWith(".localhost") ||
+        hostname === "0.0.0.0" ||
+        (ipVersion === 4 && isPrivateIPv4(hostname)) ||
+        (ipVersion === 6 && isPrivateIPv6(hostname))
+    ) {
+        throw new ImageProxyError(400, "Image URL host is not allowed.");
+    }
+
+    return parsed.toString();
+}
+
+const isAllowedImageContentType = (contentType) => {
+    const normalized = contentType.split(";")[0].trim().toLowerCase();
+
+    return (
+        normalized.startsWith("image/") ||
+        normalized === "application/octet-stream" ||
+        normalized === "binary/octet-stream"
+    );
+};
+
+export async function fetchImageForProxy(rawUrl, fetchImpl = globalThis.fetch) {
+    if (!fetchImpl) {
+        throw new ImageProxyError(500, "No fetch implementation available.");
+    }
+
+    const url = validateImageProxyUrl(rawUrl);
+    const response = await fetchImpl(url, {
+        headers: {
+            Accept: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+            "User-Agent": "nuzlocke-generator-image-proxy/1.0",
+        },
+        redirect: "follow",
+        signal: AbortSignal.timeout(IMAGE_PROXY_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+        throw new ImageProxyError(
+            response.status,
+            `Image request failed with status ${response.status}.`,
+        );
+    }
+
+    const contentType =
+        response.headers.get("content-type") || "application/octet-stream";
+
+    if (!isAllowedImageContentType(contentType)) {
+        throw new ImageProxyError(415, "URL did not return an image.");
+    }
+
+    const contentLength = Number(response.headers.get("content-length") ?? 0);
+    if (contentLength > MAX_IMAGE_BYTES) {
+        throw new ImageProxyError(413, "Image is too large.");
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_IMAGE_BYTES) {
+        throw new ImageProxyError(413, "Image is too large.");
+    }
+
+    return {
+        body: buffer,
+        contentType,
+        cacheControl:
+            "public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400",
+    };
+}

--- a/server.ts
+++ b/server.ts
@@ -8,6 +8,7 @@ import compression from "compression";
 import cors from "cors";
 import pino from "pino";
 import { fileURLToPath } from "node:url";
+import { fetchImageForProxy, ImageProxyError } from "./imageProxy.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -43,6 +44,53 @@ interface ReportArgs {
 
 const PORT = process.env.PORT || 8080;
 const distPath = path.join(__dirname, "dist");
+
+app.all("/image-proxy", async (req, res) => {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+    res.header("Access-Control-Allow-Headers", "Content-Type");
+
+    if (req.method === "OPTIONS") {
+        res.status(204).end();
+        return;
+    }
+
+    if (req.method !== "GET" && req.method !== "POST") {
+        res.status(405).send({ error: "Method not allowed." });
+        return;
+    }
+
+    const queryUrl = Array.isArray(req.query.url)
+        ? req.query.url[0]
+        : req.query.url;
+    const bodyUrl =
+        req.body && typeof req.body === "object" ? req.body.url : undefined;
+    const imageUrl =
+        req.method === "POST" && typeof bodyUrl === "string"
+            ? bodyUrl
+            : queryUrl;
+
+    try {
+        const image = await fetchImageForProxy(
+            typeof imageUrl === "string" ? imageUrl : undefined,
+        );
+
+        res.header("Cache-Control", image.cacheControl);
+        res.header("Content-Type", image.contentType);
+        res.send(image.body);
+    } catch (error) {
+        const statusCode =
+            error instanceof ImageProxyError ? error.statusCode : 502;
+        const message =
+            error instanceof Error ? error.message : "Failed to proxy image.";
+
+        logger.warn(
+            { statusCode, imageUrl, error: message },
+            "Image proxy request failed",
+        );
+        res.status(statusCode).send({ error: message });
+    }
+});
 
 app.use(express.static(distPath));
 

--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -29,6 +29,8 @@ import {
     getIconFormeSuffix,
     Species,
     Forme,
+    getDomToImageCorsOptions,
+    wrapImageInCORS,
 } from "utils";
 
 import * as Styles from "./styles";
@@ -68,6 +70,7 @@ interface ResultState {
     downloadError: string | null;
     panningCoordinates: [number?, number?];
     zoomLevel: number;
+    resultBackgroundImage?: string;
 }
 
 const ZoomValues = [
@@ -157,6 +160,8 @@ export function BackspriteMontage({ pokemon }: { pokemon: Pokemon[] }) {
 
 export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
     public resultRef: React.RefObject<HTMLDivElement>;
+    private backgroundImageRequestId = 0;
+
     public constructor(props: ResultProps) {
         super(props);
         this.resultRef = React.createRef();
@@ -165,7 +170,39 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
             downloadError: null,
             panningCoordinates: [undefined, undefined],
             zoomLevel: 1,
+            resultBackgroundImage: undefined,
         };
+    }
+
+    public componentDidMount() {
+        this.updateResultBackgroundImage();
+    }
+
+    public componentDidUpdate(prevProps: ResultProps) {
+        if (
+            prevProps.style.backgroundImage !==
+            this.props.style.backgroundImage
+        ) {
+            this.updateResultBackgroundImage();
+        }
+    }
+
+    private async updateResultBackgroundImage() {
+        const backgroundImage = this.props.style.backgroundImage;
+        const requestId = ++this.backgroundImageRequestId;
+
+        if (!backgroundImage) {
+            this.setState({ resultBackgroundImage: undefined });
+            return;
+        }
+
+        const resultBackgroundImage = backgroundImage.startsWith("http")
+            ? await wrapImageInCORS(backgroundImage)
+            : `url(${backgroundImage})`;
+
+        if (requestId === this.backgroundImageRequestId) {
+            this.setState({ resultBackgroundImage });
+        }
     }
 
     private renderTeamPokemon(teamPokemon: Pokemon[]) {
@@ -207,7 +244,7 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         try {
             const domToImage = await load();
             const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
+                ...getDomToImageCorsOptions(),
             });
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");
@@ -518,7 +555,8 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
                                 ? "0"
                                 : "3rem auto",
                             backgroundColor: bgColor,
-                            backgroundImage: `url(${style.backgroundImage})`,
+                            backgroundImage:
+                                this.state.resultBackgroundImage,
                             backgroundRepeat: style.tileBackground
                                 ? "repeat"
                                 : "no-repeat",

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -20,7 +20,7 @@ import { ErrorBoundary } from "components/Common/Shared";
 import { TopBar } from "components/Layout/TopBar/TopBar";
 import * as Styles from "./styles";
 import { TrainerResult } from "./TrainerResult";
-import { getContrastColor } from "utils";
+import { getContrastColor, getDomToImageCorsOptions } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
 
@@ -34,7 +34,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: ReturnType<typeof getDomToImageCorsOptions>,
     ) => Promise<string>;
 };
 
@@ -90,7 +90,7 @@ const toImage =
             setDS(DownloadStatus.active);
             const domToImage = await load();
             const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
+                ...getDomToImageCorsOptions(),
             });
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;

--- a/src/components/Features/Result/TrainerResult.tsx
+++ b/src/components/Features/Result/TrainerResult.tsx
@@ -15,6 +15,7 @@ import { State } from "state";
 import { Checkpoints } from "reducers/checkpoints";
 import { Stats } from "./Stats";
 import { cx } from "emotion";
+import { PokemonImage } from "components/Common/Shared/PokemonImage";
 
 export interface TrainerResultProps {
     orientation: OrientationType;
@@ -100,31 +101,39 @@ export function CheckpointsDisplay({
                 const obtained = cleared.some(
                     (b) => getClearedCheckpointName(b) === badge.name,
                 );
+                const badgeSrc =
+                    badge.image.startsWith("http") ||
+                    badge.image.startsWith("data")
+                        ? badge.image
+                        : `./img/checkpoints/${badge.image}.png`;
+                const renderBadgeImage = (image: string) => (
+                    <img
+                        className={cx(
+                            className ?? "",
+                            obtained ? "obtained" : "not-obtained",
+                        )}
+                        style={
+                            isSWSH(name) && !trainer?.hasEditedCheckpoints
+                                ? {
+                                      position: "absolute",
+                                      ...swshPositions[index],
+                                  }
+                                : {}
+                        }
+                        alt={badge.name}
+                        data-badge={badge.name}
+                        src={image}
+                    />
+                );
                 return (
                     <React.Fragment key={badge.name}>
-                        <img
-                            className={cx(
-                                className ?? "",
-                                obtained ? "obtained" : "not-obtained",
-                            )}
-                            style={
-                                isSWSH(name) && !trainer?.hasEditedCheckpoints
-                                    ? {
-                                          position: "absolute",
-                                          ...swshPositions[index],
-                                      }
-                                    : {}
-                            }
-                            key={badge.name}
-                            alt={badge.name}
-                            data-badge={badge.name}
-                            src={
-                                badge.image.startsWith("http") ||
-                                badge.image.startsWith("data")
-                                    ? badge.image
-                                    : `./img/checkpoints/${badge.image}.png`
-                            }
-                        />
+                        {badgeSrc.startsWith("http") ? (
+                            <PokemonImage url={badgeSrc}>
+                                {renderBadgeImage}
+                            </PokemonImage>
+                        ) : (
+                            renderBadgeImage(badgeSrc)
+                        )}
                         {badge.name === "Rising Badge" ? <br /> : null}
                     </React.Fragment>
                 );
@@ -169,6 +178,12 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
         const tciProps = { trainer, orientation };
         const enableStats = style.displayStats;
         const emmaMode = feature.emmaMode;
+        const trainerImage = trainer.image
+            ? mapTrainerImage(trainer.image)
+            : undefined;
+        const renderTrainerImage = (image: string) => (
+            <img className="trainer-image" src={image} alt="Trainer" />
+        );
 
         return (
             <div
@@ -201,12 +216,14 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
                 >
                     {game.customName || game.name}
                 </div>
-                {trainer.image ? (
-                    <img
-                        className="trainer-image"
-                        src={mapTrainerImage(trainer.image)}
-                        alt="Trainer"
-                    />
+                {trainerImage ? (
+                    trainerImage.startsWith("http") ? (
+                        <PokemonImage url={trainerImage}>
+                            {renderTrainerImage}
+                        </PokemonImage>
+                    ) : (
+                        renderTrainerImage(trainerImage)
+                    )
                 ) : null}
                 {trainer.title ? (
                     <div style={baseDivStyle} className="nuzlocke-title">

--- a/src/utils/__tests__/wrapImageInCORS.test.ts
+++ b/src/utils/__tests__/wrapImageInCORS.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+    getCorsImageProxyFetchUrl,
+    getDomToImageCorsOptions,
+    wrapImageInCORS,
+    wrapImageInCORSPlain,
+} from "../wrapImageInCORS";
+
+const remoteUrl = "https://example.com/image.png?token=a&size=large";
+const configuredProxyBase = import.meta.env.VITE_CORS_ANYWHERE_URL?.trim();
+const expectedProxyBase = configuredProxyBase?.replace(/\/+$/, "");
+const expectedFetchUrl = expectedProxyBase
+    ? `${expectedProxyBase}/${remoteUrl}`
+    : `/image-proxy?url=${encodeURIComponent(remoteUrl)}`;
+const expectedDomToImageOptions = expectedProxyBase
+    ? {
+          cacheBust: true,
+          corsImg: {
+              method: "GET",
+              url: `${expectedProxyBase}/#{cors}`,
+          },
+      }
+    : {
+          cacheBust: true,
+          corsImg: {
+              method: "POST",
+              url: "/image-proxy",
+              headers: { "Content-Type": "application/json" },
+              data: { url: "#{cors}" },
+          },
+      };
+
+describe("wrapImageInCORS", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("uses the configured image proxy fetch URL", () => {
+        expect(getCorsImageProxyFetchUrl(remoteUrl)).toBe(expectedFetchUrl);
+    });
+
+    it("builds dom-to-image proxy options", () => {
+        expect(getDomToImageCorsOptions()).toEqual(expectedDomToImageOptions);
+    });
+
+    it("returns a plain data URL fetched through the image proxy", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response("abc", {
+                status: 200,
+                statusText: "OK",
+                headers: { "Content-Type": "image/png" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(wrapImageInCORSPlain(remoteUrl)).resolves.toBe(
+            "data:image/png;base64,YWJj",
+        );
+        expect(fetchMock).toHaveBeenCalledWith(
+            expectedFetchUrl,
+            {
+                mode: "cors",
+                headers: {
+                    "X-Requested-With": "XMLHttpRequest",
+                },
+            },
+        );
+    });
+
+    it("wraps the proxied data URL for CSS backgrounds", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response("abc", {
+                    status: 200,
+                    statusText: "OK",
+                    headers: { "Content-Type": "image/png" },
+                }),
+            ),
+        );
+
+        await expect(wrapImageInCORS(remoteUrl)).resolves.toBe(
+            "url(data:image/png;base64,YWJj)",
+        );
+    });
+
+    it("falls back to the direct URL when the image proxy fails", async () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+
+        await expect(wrapImageInCORSPlain(remoteUrl)).resolves.toBe(remoteUrl);
+        await expect(wrapImageInCORS(remoteUrl)).resolves.toBe(
+            `url(${remoteUrl})`,
+        );
+    });
+});

--- a/src/utils/wrapImageInCORS.ts
+++ b/src/utils/wrapImageInCORS.ts
@@ -1,44 +1,106 @@
 function fileToBase64(file: Blob) {
-    return new Promise((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
         reader.readAsDataURL(file);
 
         reader.onloadend = function () {
-            resolve(reader.result);
+            resolve(reader.result as string);
         };
 
         reader.onerror = reject;
     });
 }
 
+const IMAGE_PROXY_PATH = "/image-proxy";
+const CORS_PLACEHOLDER = "#{cors}";
+
+type DomToImageCorsOptions =
+    | {
+          cacheBust: true;
+          corsImg: {
+              method: "POST";
+              url: string;
+              headers: { "Content-Type": "application/json" };
+              data: { url: string };
+          };
+      }
+    | {
+          cacheBust: true;
+          corsImg: {
+              method: "GET";
+              url: string;
+          };
+      };
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
+const getConfiguredProxyBase = () => {
+    const proxyBase = import.meta.env.VITE_CORS_ANYWHERE_URL?.trim();
+    return proxyBase ? trimTrailingSlash(proxyBase) : undefined;
+};
+
+export function getCorsImageProxyFetchUrl(url: string) {
+    const proxyBase = getConfiguredProxyBase();
+
+    if (proxyBase) {
+        return `${proxyBase}/${url}`;
+    }
+
+    return `${IMAGE_PROXY_PATH}?url=${encodeURIComponent(url)}`;
+}
+
+export function getDomToImageCorsOptions(): DomToImageCorsOptions {
+    const proxyBase = getConfiguredProxyBase();
+
+    if (proxyBase) {
+        return {
+            cacheBust: true,
+            corsImg: {
+                method: "GET",
+                url: `${proxyBase}/${CORS_PLACEHOLDER}`,
+            },
+        };
+    }
+
+    return {
+        cacheBust: true,
+        corsImg: {
+            method: "POST",
+            url: IMAGE_PROXY_PATH,
+            headers: { "Content-Type": "application/json" },
+            data: { url: CORS_PLACEHOLDER },
+        },
+    };
+}
+
+async function fetchImageAsDataUrl(url: string) {
+    const response = await fetch(getCorsImageProxyFetchUrl(url), {
+        mode: "cors",
+        headers: {
+            "X-Requested-With": "XMLHttpRequest",
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(
+            `Image proxy request failed (${response.status} ${response.statusText})`,
+        );
+    }
+
+    return fileToBase64(await response.blob());
+}
+
 export async function wrapImageInCORS(url: string) {
-    // Primary path: fetch the remote image via a CORS proxy and inline as base64.
+    // Primary path: fetch the remote image through the first-party proxy and inline as base64.
     // This allows downstream uses (e.g. canvas/export) that require CORS-safe image data.
     //
-    // In production, the proxy may be unavailable/rate-limited/blocked; in that case we
-    // fall back to the direct URL so the image still renders in the browser.
+    // If the proxy or remote host fails, fall back to the direct URL so the browser can still
+    // render hotlink-friendly images instead of leaving the result blank.
     try {
-        const proxyBase =
-            import.meta.env.VITE_CORS_ANYWHERE_URL ??
-            "https://cors-anywhere-nuzgen.herokuapp.com";
-        const response = await fetch(`${proxyBase}/${url}`, {
-            mode: "cors",
-            // origin: location.origin,
-            // @ts-expect-error valid for cors-anywhere
-            "X-Requested-With": "XMLHttpRequest",
-        });
-
-        if (!response.ok) {
-            throw new Error(
-                `CORS proxy request failed (${response.status} ${response.statusText})`,
-            );
-        }
-
-        const img = await response.blob();
-        return `url(${await fileToBase64(img)})`;
+        return `url(${await fetchImageAsDataUrl(url)})`;
     } catch (e) {
         console.warn(
-            "[wrapImageInCORS] Falling back to direct image URL (proxy failed):",
+            "[wrapImageInCORS] Falling back to direct image URL (image proxy failed):",
             url,
             e,
         );
@@ -49,26 +111,10 @@ export async function wrapImageInCORS(url: string) {
 export async function wrapImageInCORSPlain(url: string) {
     // Same as wrapImageInCORS(), but returns a plain src string for <img src="..."/>.
     try {
-        const proxyBase =
-            import.meta.env.VITE_CORS_ANYWHERE_URL ??
-            "https://cors-anywhere-nuzgen.herokuapp.com";
-        const response = await fetch(`${proxyBase}/${url}`, {
-            mode: "cors",
-            // @ts-expect-error valid for cors-anywhere
-            "X-Requested-With": "XMLHttpRequest",
-        });
-
-        if (!response.ok) {
-            throw new Error(
-                `CORS proxy request failed (${response.status} ${response.statusText})`,
-            );
-        }
-
-        const img = await response.blob();
-        return `${await fileToBase64(img)}`;
+        return await fetchImageAsDataUrl(url);
     } catch (e) {
         console.warn(
-            "[wrapImageInCORSPlain] Falling back to direct image URL (proxy failed):",
+            "[wrapImageInCORSPlain] Falling back to direct image URL (image proxy failed):",
             url,
             e,
         );

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
             "destination": "/api/server"
         },
         {
+            "source": "/image-proxy",
+            "destination": "/api/server"
+        },
+        {
             "source": "/nuzlocke",
             "destination": "/api/server"
         },

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,15 +7,96 @@ import dotenv from "dotenv";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from "path";
+import { fetchImageForProxy, ImageProxyError } from "./imageProxy.js";
 
 dotenv.config();
 
 const isProduction = process.env.NODE_ENV === "production";
 
+const readJsonBody = (req) =>
+    new Promise((resolve, reject) => {
+        const chunks = [];
+
+        req.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        req.on("error", reject);
+        req.on("end", () => {
+            if (chunks.length === 0) {
+                resolve({});
+                return;
+            }
+
+            try {
+                resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+            } catch (error) {
+                reject(error);
+            }
+        });
+    });
+
+const sendImageProxyError = (res, statusCode, message) => {
+    res.statusCode = statusCode;
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ error: message }));
+};
+
+const imageProxyDevServer = () => ({
+    name: "image-proxy-dev-server",
+    configureServer(server) {
+        server.middlewares.use("/image-proxy", async (req, res) => {
+            res.setHeader("Access-Control-Allow-Origin", "*");
+            res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+            res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+            if (req.method === "OPTIONS") {
+                res.statusCode = 204;
+                res.end();
+                return;
+            }
+
+            if (req.method !== "GET" && req.method !== "POST") {
+                sendImageProxyError(res, 405, "Method not allowed.");
+                return;
+            }
+
+            try {
+                const queryUrl = new URL(
+                    req.url ?? "",
+                    "http://localhost",
+                ).searchParams.get("url");
+                const body =
+                    req.method === "POST" ? await readJsonBody(req) : {};
+                const bodyUrl =
+                    body && typeof body === "object" ? body.url : undefined;
+                const imageUrl =
+                    req.method === "POST" && typeof bodyUrl === "string"
+                        ? bodyUrl
+                        : queryUrl;
+                const image = await fetchImageForProxy(imageUrl);
+
+                res.statusCode = 200;
+                res.setHeader("Cache-Control", image.cacheControl);
+                res.setHeader("Content-Type", image.contentType);
+                res.end(image.body);
+            } catch (error) {
+                const statusCode =
+                    error instanceof ImageProxyError ? error.statusCode : 502;
+                const message =
+                    error instanceof Error
+                        ? error.message
+                        : "Failed to proxy image.";
+
+                sendImageProxyError(res, statusCode, message);
+            }
+        });
+    },
+});
+
 export default defineConfig({
     root: "./",
     base: "/",
     plugins: [
+        imageProxyDevServer(),
         react(),
         tsconfigPaths(),
         // Copy static assets


### PR DESCRIPTION
## Summary

Fixes ART-14 / GitHub #495 #476 #455 #464 #477 by replacing the deprecated external CORS-anywhere default with a first-party image proxy and wiring the download renderer to use it.

The result export path was passing `corsImage: true`, but the `@emmaramirez/dom-to-image` fork expects `corsImg`, so remote resources could still be fetched directly during PNG generation and be dropped by CORS. Remote custom Pokémon images, trainer images, badges, sprites, and result backgrounds now go through a same-origin `/image-proxy` endpoint before being rendered or exported.

## Changes

- Add a shared image proxy helper and expose `/image-proxy` from both Express/Vercel and the Vite dev server.
- Update CORS image helpers to inline remote images through the first-party proxy, with a direct-URL fallback if proxying fails.
- Pass the correct `corsImg` POST proxy configuration into both result download implementations.
- Proxy remote trainer images, custom badge images, and result background images before they are used in the downloadable output.
- Add Vitest coverage for proxy URL generation, dom-to-image options, data URL inlining, and fallback behavior.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/utils/__tests__/wrapImageInCORS.test.ts`
- `npm run build`
- Manual Vite `/image-proxy` GET and POST checks against a remote JPEG returned `200 OK` and valid JPEG bytes.
- Manual Express `/image-proxy` POST check returned `200 OK` and valid JPEG bytes.
- Headless Chromium verified `dom-to-image.toPng()` with remote `<img>` and background resources using the POST `/image-proxy` config returned a PNG data URL.
