### PR TITLE
fix download CORS proxy options

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -29,6 +29,7 @@ import {
     getIconFormeSuffix,
     Species,
     Forme,
+    getDomToImageDownloadOptions,
 } from "utils";
 
 import * as Styles from "./styles";
@@ -206,9 +207,10 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         this.setState({ isDownloading: true });
         try {
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDomToImageDownloadOptions(),
+            );
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -20,7 +20,11 @@ import { ErrorBoundary } from "components/Common/Shared";
 import { TopBar } from "components/Layout/TopBar/TopBar";
 import * as Styles from "./styles";
 import { TrainerResult } from "./TrainerResult";
-import { getContrastColor } from "utils";
+import {
+    DomToImageDownloadOptions,
+    getContrastColor,
+    getDomToImageDownloadOptions,
+} from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
 
@@ -34,7 +38,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: DomToImageDownloadOptions,
     ) => Promise<string>;
 };
 
@@ -89,9 +93,10 @@ const toImage =
         try {
             setDS(DownloadStatus.active);
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDomToImageDownloadOptions(),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { ResultBase, BackspriteMontage } from "../Result";
 import { styleDefaults, generateEmptyPokemon } from "utils";
@@ -9,6 +9,14 @@ type ResultBaseProps = React.ComponentProps<typeof ResultBase>;
 type PokemonSpeciesProps = { species: string };
 type PokemonProp = { pokemon: Pokemon };
 type ChildrenProps = { children?: React.ReactNode };
+
+const domToImageMock = vi.hoisted(() => ({
+    toPng: vi.fn(),
+}));
+
+vi.mock("@emmaramirez/dom-to-image", () => ({
+    domToImage: domToImageMock,
+}));
 
 vi.mock("components/Pokemon/TeamPokemon/TeamPokemon", () => ({
     TeamPokemon: ({ pokemon }: PokemonProp) => (
@@ -39,8 +47,19 @@ vi.mock("components/Features/Result/TrainerResult", () => ({
 }));
 
 vi.mock("components/Layout/TopBar/TopBar", () => ({
-    TopBar: ({ children }: { children?: React.ReactNode }) => (
-        <div data-testid="top-bar">{children}</div>
+    TopBar: ({
+        children,
+        onClickDownload,
+    }: {
+        children?: React.ReactNode;
+        onClickDownload?: () => void;
+    }) => (
+        <div data-testid="top-bar">
+            <button onClick={onClickDownload} type="button">
+                Download
+            </button>
+            {children}
+        </div>
     ),
 }));
 
@@ -94,6 +113,13 @@ const createPokemon = () => [
 ];
 
 describe("<ResultBase />", () => {
+    beforeEach(() => {
+        domToImageMock.toPng.mockReset();
+        domToImageMock.toPng.mockResolvedValue(
+            "data:image/png;base64,result",
+        );
+    });
+
     it("renders team and status sections with rules", () => {
         render(
             <ResultBase
@@ -123,6 +149,58 @@ describe("<ResultBase />", () => {
         expect(screen.getByText("Boxed")).toBeTruthy();
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
+    });
+
+    it("uses dom-to-image CORS proxy options for result downloads", async () => {
+        const clickSpy = vi
+            .spyOn(HTMLAnchorElement.prototype, "click")
+            .mockImplementation(() => undefined);
+
+        render(
+            <ResultBase
+                pokemon={createPokemon()}
+                game={{ name: "Red", customName: "" }}
+                trainer={{ notes: "Remember to heal", badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    displayRules: true,
+                    displayRulesLocation: "top",
+                    trainerSectionOrientation: "horizontal",
+                    useSpritesForChampsPokemon: true,
+                }}
+                rules={["Rule 1", "Rule 2"]}
+                customTypes={[]}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+        await waitFor(() => {
+            expect(domToImageMock.toPng).toHaveBeenCalled();
+        });
+
+        expect(domToImageMock.toPng).toHaveBeenCalledWith(
+            expect.any(HTMLDivElement),
+            {
+                corsImg: {
+                    method: "GET",
+                    url: "https://cors-anywhere-nuzgen.herokuapp.com/#{cors}",
+                    data: {},
+                },
+                imagePlaceholder:
+                    "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",
+            },
+        );
+        expect(clickSpy).toHaveBeenCalled();
+
+        clickSpy.mockRestore();
     });
 });
 

--- a/src/utils/domToImageDownloadOptions.ts
+++ b/src/utils/domToImageDownloadOptions.ts
@@ -1,0 +1,30 @@
+const DEFAULT_CORS_PROXY_URL = "https://cors-anywhere-nuzgen.herokuapp.com";
+
+const TRANSPARENT_IMAGE_PLACEHOLDER =
+    "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==";
+
+export interface DomToImageDownloadOptions {
+    corsImg: {
+        method: "GET";
+        url: string;
+        data: Record<string, never>;
+    };
+    imagePlaceholder: string;
+}
+
+export function getCorsProxyBaseUrl() {
+    return (
+        import.meta.env.VITE_CORS_ANYWHERE_URL ?? DEFAULT_CORS_PROXY_URL
+    ).replace(/\/$/, "");
+}
+
+export function getDomToImageDownloadOptions(): DomToImageDownloadOptions {
+    return {
+        corsImg: {
+            method: "GET",
+            url: `${getCorsProxyBaseUrl()}/#{cors}`,
+            data: {},
+        },
+        imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
+    };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,6 +22,7 @@ export * from "./handleMovesGenerationExceptions";
 export * from "./dragAndDrop";
 export * from "./debounce";
 export * from "./DeepSet";
+export * from "./domToImageDownloadOptions";
 export * from "./isEmpty";
 export * from "./Forme";
 export * from "./isLocal";

--- a/src/utils/wrapImageInCORS.ts
+++ b/src/utils/wrapImageInCORS.ts
@@ -1,3 +1,5 @@
+import { getCorsProxyBaseUrl } from "./domToImageDownloadOptions";
+
 function fileToBase64(file: Blob) {
     return new Promise((resolve, reject) => {
         const reader = new FileReader();
@@ -18,10 +20,7 @@ export async function wrapImageInCORS(url: string) {
     // In production, the proxy may be unavailable/rate-limited/blocked; in that case we
     // fall back to the direct URL so the image still renders in the browser.
     try {
-        const proxyBase =
-            import.meta.env.VITE_CORS_ANYWHERE_URL ??
-            "https://cors-anywhere-nuzgen.herokuapp.com";
-        const response = await fetch(`${proxyBase}/${url}`, {
+        const response = await fetch(`${getCorsProxyBaseUrl()}/${url}`, {
             mode: "cors",
             // origin: location.origin,
             // @ts-expect-error valid for cors-anywhere
@@ -49,10 +48,7 @@ export async function wrapImageInCORS(url: string) {
 export async function wrapImageInCORSPlain(url: string) {
     // Same as wrapImageInCORS(), but returns a plain src string for <img src="..."/>.
     try {
-        const proxyBase =
-            import.meta.env.VITE_CORS_ANYWHERE_URL ??
-            "https://cors-anywhere-nuzgen.herokuapp.com";
-        const response = await fetch(`${proxyBase}/${url}`, {
+        const response = await fetch(`${getCorsProxyBaseUrl()}/${url}`, {
             mode: "cors",
             // @ts-expect-error valid for cors-anywhere
             "X-Requested-With": "XMLHttpRequest",


### PR DESCRIPTION
## Summary

Fixes the result image download path for sprites-for-champs and other cross-origin result images by using the `@emmaramirez/dom-to-image` option the library actually reads.

## Root cause

The result download code passed `corsImage: true` to `domToImage.toPng()`, but the installed library expects a `corsImg` proxy configuration object. Because the boolean option was ignored, cross-origin sprite URLs could still reach the export render and fail or stall the PNG generation.

## Changes

- Added a shared `getDomToImageDownloadOptions()` helper with the CORS proxy URL template and transparent fallback placeholder.
- Switched both result download implementations from `corsImage` to `corsImg`.
- Reused the same proxy base helper in `wrapImageInCORS` so image preloading and export-time proxying stay aligned.
- Added a regression test that clicks the result download control and verifies `dom-to-image` receives the CORS proxy options.

Related: #952 #726 #465 #676

## Validation

- `npm run typecheck`
- `npm run lint -- src/components/Features/Result/Result.tsx src/components/Features/Result/Result2.tsx src/components/Features/Result/__tests__/Result.test.tsx src/utils/domToImageDownloadOptions.ts src/utils/wrapImageInCORS.ts src/utils/index.ts`
- `npx vitest run src/components/Features/Result/__tests__/Result.test.tsx src/utils/getters/__tests__/getPokemonImage.test.ts`
- `npm run test:run`
- Husky pre-commit `npm run lint`
