### PR TITLE
Fix custom image downloads

### DIFF
--- a/e2e/download-custom-images.spec.ts
+++ b/e2e/download-custom-images.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+import { statSync } from "node:fs";
+
+const transparentPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAEElEQVR42mP8z8BQDwAFgwJ/lxGH5QAAAABJRU5ErkJggg==",
+    "base64",
+);
+
+const persistState = (state: Record<string, unknown>) =>
+    JSON.stringify({
+        ...Object.fromEntries(
+            Object.entries(state).map(([key, value]) => [
+                key,
+                JSON.stringify(value),
+            ]),
+        ),
+        _persist: JSON.stringify({
+            version: "1.23.0",
+            rehydrated: true,
+        }),
+    });
+
+test("downloads a result with custom remote portraits, icons, and checkpoints", async ({
+    page,
+}) => {
+    await page.route("https://cors-anywhere-nuzgen.herokuapp.com/**", (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: "image/png",
+            body: transparentPng,
+        }),
+    );
+
+    await page.addInitScript((persistedState) => {
+        window.localStorage.setItem("persist:root", persistedState);
+    }, persistState({
+        box: [
+            { id: 0, position: 0, name: "Team" },
+            { id: 1, position: 1, name: "Boxed" },
+            { id: 2, position: 2, name: "Dead" },
+            { id: 3, position: 3, name: "Champs" },
+        ],
+        checkpoints: [
+            {
+                name: "Legend Ribbon",
+                image: "https://cdn2.bulbagarden.net/upload/d/d4/Legend_Ribbon.png",
+            },
+        ],
+        game: { name: "Crystal", customName: "" },
+        pokemon: [
+            {
+                id: "team-1",
+                position: 0,
+                species: "Mew",
+                nickname: "Andromeda",
+                status: "Team",
+                gender: "genderless",
+                level: "56",
+                nature: "None",
+                types: ["Psychic", "Psychic"],
+                moves: ["Psychic"],
+                customImage: "https://i.imgur.com/custom-portrait.png",
+                customItemImage: "https://i.imgur.com/custom-item.png",
+            },
+            {
+                id: "box-1",
+                position: 1,
+                species: "Perrserker",
+                nickname: "Vinland",
+                status: "Boxed",
+                gender: "Female",
+                types: ["Steel", "Steel"],
+                customIcon: "https://www.serebii.net/pokedex-swsh/icon/863.png",
+            },
+        ],
+        selectedId: "team-1",
+        trainer: {
+            badges: [{ name: "Legend Ribbon", image: "legend-ribbon" }],
+            image: "https://i.imgur.com/custom-trainer.png",
+            title: "Custom image regression",
+        },
+    }));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator(".trainer-image")).toHaveAttribute(
+        "src",
+        /^data:image\/png/,
+    );
+    await expect(page.locator(".trainer-checkpoint")).toHaveAttribute(
+        "src",
+        /^data:image\/png/,
+    );
+    await expect(page.locator(".pokemon-item img")).toHaveAttribute(
+        "src",
+        /^data:image\/png/,
+    );
+    await expect(page.locator(".boxed-pokemon-icon img")).toHaveAttribute(
+        "src",
+        /^data:image\/png/,
+    );
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByTestId("download-image-button").click();
+    const download = await downloadPromise;
+    const path = await download.path();
+
+    expect(download.suggestedFilename()).toMatch(/^nuzlocke-.*\.png$/);
+    expect(path ? statSync(path).size : 0).toBeGreaterThan(0);
+});
+

--- a/src/components/Common/Shared/PokemonImage.tsx
+++ b/src/components/Common/Shared/PokemonImage.tsx
@@ -2,7 +2,7 @@ import {} from "@blueprintjs/core";
 import { Pokemon } from "models";
 import * as React from "react";
 import { State } from "state";
-import { getPokemonImage, wrapImageInCORSPlain } from "utils";
+import { getPokemonImage, isRemoteImageUrl, wrapImageInCORSPlain } from "utils";
 import { getImageByName } from "components/Common/Shared/ImagesDrawer";
 
 export interface PokemonImageProps {
@@ -51,7 +51,7 @@ export function PokemonImage({
                     // Then fall back to the historical behavior:
                     // - http(s): use CORS proxy -> data URL
                     // - otherwise: treat as a direct src (data:, relative path, etc.)
-                    if (url.startsWith("http")) {
+                    if (isRemoteImageUrl(url)) {
                         setImage(await wrapImageInCORSPlain(url));
                     } else {
                         setImage(url);

--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -29,6 +29,7 @@ import {
     getIconFormeSuffix,
     Species,
     Forme,
+    getDomToImageOptions,
 } from "utils";
 
 import * as Styles from "./styles";
@@ -206,9 +207,10 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         this.setState({ isDownloading: true });
         try {
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDomToImageOptions(),
+            );
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -20,7 +20,7 @@ import { ErrorBoundary } from "components/Common/Shared";
 import { TopBar } from "components/Layout/TopBar/TopBar";
 import * as Styles from "./styles";
 import { TrainerResult } from "./TrainerResult";
-import { getContrastColor } from "utils";
+import { getContrastColor, getDomToImageOptions } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
 
@@ -34,7 +34,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: ReturnType<typeof getDomToImageOptions>,
     ) => Promise<string>;
 };
 
@@ -89,9 +89,10 @@ const toImage =
         try {
             setDS(DownloadStatus.active);
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getDomToImageOptions(),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/TrainerResult.tsx
+++ b/src/components/Features/Result/TrainerResult.tsx
@@ -8,6 +8,7 @@ import {
     getBadges,
     isEmpty,
     feature,
+    isRemoteImageUrl,
 } from "utils";
 import { connect, useSelector } from "store/reactZustand";
 import { Trainer, Badge } from "models";
@@ -15,6 +16,7 @@ import { State } from "state";
 import { Checkpoints } from "reducers/checkpoints";
 import { Stats } from "./Stats";
 import { cx } from "emotion";
+import { PokemonImage } from "components/Common/Shared/PokemonImage";
 
 export interface TrainerResultProps {
     orientation: OrientationType;
@@ -83,6 +85,11 @@ export function CheckpointsDisplay({
         return null;
     }
 
+    const checkpointImageURL = (badgeImage: string) =>
+        isRemoteImageUrl(badgeImage) || badgeImage.startsWith("data")
+            ? badgeImage
+            : `./img/checkpoints/${badgeImage}.png`;
+
     const swshPositions = [
         { bottom: 0, right: 0 },
         { right: "-9px", top: "2px", height: "24px" },
@@ -102,29 +109,29 @@ export function CheckpointsDisplay({
                 );
                 return (
                     <React.Fragment key={badge.name}>
-                        <img
-                            className={cx(
-                                className ?? "",
-                                obtained ? "obtained" : "not-obtained",
+                        <PokemonImage url={checkpointImageURL(badge.image)}>
+                            {(image) => (
+                                <img
+                                    className={cx(
+                                        className ?? "",
+                                        obtained ? "obtained" : "not-obtained",
+                                    )}
+                                    style={
+                                        isSWSH(name) &&
+                                        !trainer?.hasEditedCheckpoints
+                                            ? {
+                                                  position: "absolute",
+                                                  ...swshPositions[index],
+                                              }
+                                            : {}
+                                    }
+                                    key={badge.name}
+                                    alt={badge.name}
+                                    data-badge={badge.name}
+                                    src={image}
+                                />
                             )}
-                            style={
-                                isSWSH(name) && !trainer?.hasEditedCheckpoints
-                                    ? {
-                                          position: "absolute",
-                                          ...swshPositions[index],
-                                      }
-                                    : {}
-                            }
-                            key={badge.name}
-                            alt={badge.name}
-                            data-badge={badge.name}
-                            src={
-                                badge.image.startsWith("http") ||
-                                badge.image.startsWith("data")
-                                    ? badge.image
-                                    : `./img/checkpoints/${badge.image}.png`
-                            }
-                        />
+                        </PokemonImage>
                         {badge.name === "Rising Badge" ? <br /> : null}
                     </React.Fragment>
                 );
@@ -202,11 +209,15 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
                     {game.customName || game.name}
                 </div>
                 {trainer.image ? (
-                    <img
-                        className="trainer-image"
-                        src={mapTrainerImage(trainer.image)}
-                        alt="Trainer"
-                    />
+                    <PokemonImage url={mapTrainerImage(trainer.image)}>
+                        {(image) => (
+                            <img
+                                className="trainer-image"
+                                src={image}
+                                alt="Trainer"
+                            />
+                        )}
+                    </PokemonImage>
                 ) : null}
                 {trainer.title ? (
                     <div style={baseDivStyle} className="nuzlocke-title">

--- a/src/utils/__tests__/downloadImages.test.ts
+++ b/src/utils/__tests__/downloadImages.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+    DEFAULT_CORS_PROXY_BASE,
+    TRANSPARENT_IMAGE_PLACEHOLDER,
+    getCorsProxyUrl,
+    getDomToImageOptions,
+    isRemoteImageUrl,
+} from "../downloadImages";
+
+describe("@src/utils/downloadImages.ts", () => {
+    it("detects only http(s) image URLs as remote", () => {
+        expect(isRemoteImageUrl("https://example.com/pokemon.png")).toBe(true);
+        expect(isRemoteImageUrl("http://example.com/pokemon.png")).toBe(true);
+        expect(isRemoteImageUrl("data:image/png;base64,abc")).toBe(false);
+        expect(isRemoteImageUrl("./img/checkpoints/boulder-badge.png")).toBe(
+            false,
+        );
+    });
+
+    it("builds CORS proxy URLs for dom-to-image and direct fetches", () => {
+        const url = "https://cdn2.bulbagarden.net/upload/d/d4/Legend_Ribbon.png";
+
+        expect(getCorsProxyUrl(url)).toBe(`${DEFAULT_CORS_PROXY_BASE}/${url}`);
+        expect(getDomToImageOptions()).toEqual({
+            cacheBust: true,
+            imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
+            corsImg: {
+                url: `${DEFAULT_CORS_PROXY_BASE}/#{cors}`,
+                headers: {
+                    "X-Requested-With": "XMLHttpRequest",
+                },
+            },
+        });
+    });
+});
+

--- a/src/utils/downloadImages.ts
+++ b/src/utils/downloadImages.ts
@@ -1,0 +1,35 @@
+export const DEFAULT_CORS_PROXY_BASE =
+    "https://cors-anywhere-nuzgen.herokuapp.com";
+
+export const TRANSPARENT_IMAGE_PLACEHOLDER =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAEElEQVR42mP8z8BQDwAFgwJ/lxGH5QAAAABJRU5ErkJggg==";
+
+export type DomToImageOptions = {
+    cacheBust: boolean;
+    imagePlaceholder: string;
+    corsImg: {
+        url: string;
+        headers: Record<string, string>;
+    };
+};
+
+export const isRemoteImageUrl = (url: string) => /^https?:\/\//i.test(url);
+
+export const getCorsProxyBase = () =>
+    (
+        import.meta.env.VITE_CORS_ANYWHERE_URL || DEFAULT_CORS_PROXY_BASE
+    ).replace(/\/$/, "");
+
+export const getCorsProxyUrl = (url: string) => `${getCorsProxyBase()}/${url}`;
+
+export const getDomToImageOptions = (): DomToImageOptions => ({
+    cacheBust: true,
+    imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
+    corsImg: {
+        url: `${getCorsProxyBase()}/#{cors}`,
+        headers: {
+            "X-Requested-With": "XMLHttpRequest",
+        },
+    },
+});
+

--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -63,6 +63,7 @@ vi.mock("utils", () => ({
     getForme: mocks.getForme,
     addForme: mocks.addForme,
     wrapImageInCORS: mocks.wrapImageInCORS,
+    isRemoteImageUrl: (url: string) => /^https?:\/\//i.test(url),
     normalizeSpeciesName: mocks.normalizeSpeciesName,
     capitalize: mocks.capitalize,
 }));
@@ -408,4 +409,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -7,6 +7,7 @@ import {
     significantGenderDifferenceList,
     wrapImageInCORS,
     normalizeSpeciesName,
+    isRemoteImageUrl,
 } from "utils";
 import { getIconFormeSuffix } from "./getIconFormeSuffix";
 import { Editor, Pokemon } from "models";
@@ -164,7 +165,7 @@ export async function getPokemonImage({
         if (selectedImage) {
             return `url(${selectedImage})`;
         }
-        if (customImage.startsWith("http")) {
+        if (isRemoteImageUrl(customImage)) {
             return await wrapImageInCORS(customImage);
         }
         return `url(${customImage})`;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,6 +28,7 @@ export * from "./isLocal";
 export * from "./feature";
 export * from "./matchNatureToToxtricityForme";
 export * from "./handleSignificantGenderDifferences";
+export * from "./downloadImages";
 export * from "./wrapImageInCORS";
 export * from "./gameSaveFormat";
 export * from "./getters/normalizeSpeciesName";

--- a/src/utils/wrapImageInCORS.ts
+++ b/src/utils/wrapImageInCORS.ts
@@ -1,31 +1,33 @@
+import { getCorsProxyUrl, isRemoteImageUrl } from "./downloadImages";
+
 function fileToBase64(file: Blob) {
-    return new Promise((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
         reader.readAsDataURL(file);
 
         reader.onloadend = function () {
-            resolve(reader.result);
+            if (typeof reader.result === "string") {
+                resolve(reader.result);
+                return;
+            }
+            reject(new Error("Expected FileReader to return a data URL."));
         };
 
         reader.onerror = reject;
     });
 }
 
-export async function wrapImageInCORS(url: string) {
-    // Primary path: fetch the remote image via a CORS proxy and inline as base64.
-    // This allows downstream uses (e.g. canvas/export) that require CORS-safe image data.
-    //
-    // In production, the proxy may be unavailable/rate-limited/blocked; in that case we
-    // fall back to the direct URL so the image still renders in the browser.
+async function fetchImageViaCorsProxy(url: string) {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 15_000);
+
     try {
-        const proxyBase =
-            import.meta.env.VITE_CORS_ANYWHERE_URL ??
-            "https://cors-anywhere-nuzgen.herokuapp.com";
-        const response = await fetch(`${proxyBase}/${url}`, {
+        const response = await fetch(getCorsProxyUrl(url), {
             mode: "cors",
-            // origin: location.origin,
-            // @ts-expect-error valid for cors-anywhere
-            "X-Requested-With": "XMLHttpRequest",
+            signal: controller.signal,
+            headers: {
+                "X-Requested-With": "XMLHttpRequest",
+            },
         });
 
         if (!response.ok) {
@@ -35,7 +37,28 @@ export async function wrapImageInCORS(url: string) {
         }
 
         const img = await response.blob();
-        return `url(${await fileToBase64(img)})`;
+        if (img.type && !img.type.startsWith("image/")) {
+            throw new Error(`CORS proxy returned non-image content (${img.type})`);
+        }
+
+        return fileToBase64(img);
+    } finally {
+        window.clearTimeout(timeout);
+    }
+}
+
+export async function wrapImageInCORS(url: string): Promise<string> {
+    if (!isRemoteImageUrl(url)) {
+        return `url(${url})`;
+    }
+
+    // Primary path: fetch the remote image via a CORS proxy and inline as base64.
+    // This allows downstream uses (e.g. canvas/export) that require CORS-safe image data.
+    //
+    // In production, the proxy may be unavailable/rate-limited/blocked; in that case we
+    // fall back to the direct URL so the image still renders in the browser.
+    try {
+        return `url(${await fetchImageViaCorsProxy(url)})`;
     } catch (e) {
         console.warn(
             "[wrapImageInCORS] Falling back to direct image URL (proxy failed):",
@@ -46,26 +69,14 @@ export async function wrapImageInCORS(url: string) {
     }
 }
 
-export async function wrapImageInCORSPlain(url: string) {
+export async function wrapImageInCORSPlain(url: string): Promise<string> {
+    if (!isRemoteImageUrl(url)) {
+        return url;
+    }
+
     // Same as wrapImageInCORS(), but returns a plain src string for <img src="..."/>.
     try {
-        const proxyBase =
-            import.meta.env.VITE_CORS_ANYWHERE_URL ??
-            "https://cors-anywhere-nuzgen.herokuapp.com";
-        const response = await fetch(`${proxyBase}/${url}`, {
-            mode: "cors",
-            // @ts-expect-error valid for cors-anywhere
-            "X-Requested-With": "XMLHttpRequest",
-        });
-
-        if (!response.ok) {
-            throw new Error(
-                `CORS proxy request failed (${response.status} ${response.statusText})`,
-            );
-        }
-
-        const img = await response.blob();
-        return `${await fileToBase64(img)}`;
+        return await fetchImageViaCorsProxy(url);
     } catch (e) {
         console.warn(
             "[wrapImageInCORSPlain] Falling back to direct image URL (proxy failed):",


### PR DESCRIPTION
## Summary

Fixes the download path for result images that include user-provided remote assets: custom Pokémon portraits, custom icons, custom item images, trainer portraits, and custom checkpoint/badge images such as Bulbapedia URLs.

The previous download call passed `corsImage`, but the `@emmaramirez/dom-to-image` fork expects `corsImg`, so remaining remote `<img>`/background resources were fetched directly during export. Some result images also rendered trainer/checkpoint URLs directly instead of going through the existing image wrapper. Those resources could stall, taint the canvas, or be omitted when users attempted to download.

## Changes

- Added shared download image helpers for CORS proxy URLs, dom-to-image options, and a transparent fallback placeholder.
- Updated both Result download flows to pass the correct `corsImg` option with cache busting and fallback image placeholder.
- Reworked remote image wrapping to send headers correctly, time out stalled proxy fetches, reject non-image proxy responses, and preserve direct rendering fallback.
- Routed trainer portraits and checkpoint images through the same safe image wrapper used by custom Pokémon portraits/icons.
- Added unit coverage for the download image helper and an e2e regression that downloads a result with custom remote portraits, icons, item images, and Bulbapedia-style checkpoints.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run typecheck`
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run lint`
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run test:run`
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run build`
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npx playwright test e2e/download-custom-images.spec.ts --project=chromium`

Closes #642, #620, #508, #454, #423, #447.
