### PR TITLE
Add custom item image scaling support

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -455,6 +455,17 @@ export class CurrentPokemonEditBase extends React.Component<
                     key={this.state.selectedId + "customItemImage"}
                 />
                 <CurrentPokemonInput
+                    labelName="Custom Item Image Scale (%)"
+                    inputName="customItemImageScale"
+                    placeholder="100"
+                    value={currentPokemon.customItemImageScale ?? 100}
+                    type="number"
+                    min="1"
+                    max="200"
+                    step="5"
+                    key={this.state.selectedId + "customItemImageScale"}
+                />
+                <CurrentPokemonInput
                     labelName="Poké Ball"
                     inputName="pokeball"
                     value={normalizePokeballName(currentPokemon.pokeball)}

--- a/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
@@ -47,6 +47,9 @@ interface CurrentPokemonInputProps {
         | "rich-text";
     value: PokemonInputValue;
     placeholder?: string;
+    min?: string | number;
+    max?: string | number;
+    step?: string | number;
     transform?: (v: PokemonInputValue) => string;
     disabled?: boolean;
     options?: SelectOption[];
@@ -236,9 +239,11 @@ export function PokemonTextAreaInput({
 export function PokemonNumberInput({
     inputName,
     type,
-    value,
     placeholder,
     disabled,
+    min,
+    max,
+    step,
     onChange,
     setEdit,
     edit,
@@ -252,6 +257,9 @@ export function PokemonNumberInput({
             value={String(edit[inputName] ?? "")}
             placeholder={placeholder}
             disabled={disabled}
+            min={min}
+            max={max}
+            step={step}
         />
     );
 }

--- a/src/components/Pokemon/TeamPokemon/PokemonItem.tsx
+++ b/src/components/Pokemon/TeamPokemon/PokemonItem.tsx
@@ -6,6 +6,24 @@ import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { ResizedImage } from "components/Common/Shared/ResizedImage";
 import { getBackgroundGradient, getHeldItemIconPath, typeToColor } from "utils";
 
+const DEFAULT_CUSTOM_ITEM_IMAGE_SCALE = 100;
+const MIN_CUSTOM_ITEM_IMAGE_SCALE = 1;
+const MAX_CUSTOM_ITEM_IMAGE_SCALE = 200;
+
+export function getCustomItemImageScale(
+    scale: Pokemon["customItemImageScale"],
+) {
+    if (scale == null || scale === "") return DEFAULT_CUSTOM_ITEM_IMAGE_SCALE;
+
+    const numericScale = Number(scale);
+    if (!Number.isFinite(numericScale)) return DEFAULT_CUSTOM_ITEM_IMAGE_SCALE;
+
+    return Math.min(
+        MAX_CUSTOM_ITEM_IMAGE_SCALE,
+        Math.max(MIN_CUSTOM_ITEM_IMAGE_SCALE, numericScale),
+    );
+}
+
 const itemLabelStyle = {
     base: css`
         background: #111;
@@ -50,6 +68,9 @@ export function PokemonItem({
     customTypes: State["customTypes"];
 }) {
     const getSecondType = pokemon?.types?.[1] || "Normal";
+    const customItemImageScale = `${getCustomItemImageScale(
+        pokemon.customItemImageScale,
+    )}%`;
 
     return (pokemon.item || pokemon.customItemImage) &&
         !style.displayItemAsText ? (
@@ -87,8 +108,8 @@ export function PokemonItem({
                             height={64}
                             alt={pokemon.item}
                             style={{
-                                width: "100%",
-                                height: "100%",
+                                width: customItemImageScale,
+                                height: customItemImageScale,
                                 objectFit: "contain",
                             }}
                         />

--- a/src/components/Pokemon/TeamPokemon/__tests__/PokemonItem.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/PokemonItem.test.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Pokemon } from "models";
+import { styleDefaults, Types } from "utils";
+import {
+    getCustomItemImageScale,
+    PokemonItem,
+} from "../PokemonItem";
+
+vi.mock("components/Common/Shared/PokemonImage", () => ({
+    PokemonImage: ({ children }) => children("custom-item.png"),
+}));
+
+const basePokemon: Pokemon = {
+    id: "item-test",
+    species: "Pikachu",
+    item: "Lucky Egg",
+    customItemImage: "custom-lucky-egg",
+    types: [Types.Electric, Types.Electric],
+};
+
+describe(PokemonItem.name, () => {
+    it("renders custom item images at the default scale", () => {
+        render(
+            <PokemonItem
+                pokemon={basePokemon}
+                style={styleDefaults}
+                customTypes={[]}
+            />,
+        );
+
+        const image = screen.getByAltText("Lucky Egg");
+        expect(image.style.width).toBe("100%");
+        expect(image.style.height).toBe("100%");
+    });
+
+    it("applies a custom item image scale percentage", () => {
+        render(
+            <PokemonItem
+                pokemon={{ ...basePokemon, customItemImageScale: 50 }}
+                style={styleDefaults}
+                customTypes={[]}
+            />,
+        );
+
+        const image = screen.getByAltText("Lucky Egg");
+        expect(image.style.width).toBe("50%");
+        expect(image.style.height).toBe("50%");
+    });
+});
+
+describe(getCustomItemImageScale.name, () => {
+    it("defaults blank or invalid scales and clamps out-of-range values", () => {
+        expect(getCustomItemImageScale(undefined)).toBe(100);
+        expect(getCustomItemImageScale("")).toBe(100);
+        expect(getCustomItemImageScale("not a number")).toBe(100);
+        expect(getCustomItemImageScale(-10)).toBe(1);
+        expect(getCustomItemImageScale(250)).toBe(200);
+    });
+});

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -23,6 +23,7 @@ export interface Pokemon {
     customImage?: string;
     customIcon?: string;
     customItemImage?: string;
+    customItemImageScale?: number | string;
     shiny?: boolean;
     badges?: string[];
     num?: string;
@@ -65,6 +66,7 @@ export const PokemonKeys: Pokemon = {
     customImage: "",
     customIcon: "",
     customItemImage: "",
+    customItemImageScale: 100,
     shiny: false,
     champion: false,
     badges: [],

--- a/src/utils/generateEmptyPokemon.ts
+++ b/src/utils/generateEmptyPokemon.ts
@@ -41,6 +41,7 @@ export function generateEmptyPokemon(
         types: [Types.Normal, Types.Normal],
         egg: false,
         gift: false,
+        customItemImageScale: 100,
         ...(overrides ?? {}),
     };
 }


### PR DESCRIPTION
## Summary

Adds explicit custom item image scaling so users do not have to resize uploaded item artwork or discover a CSS workaround.

- Adds a per-Pokemon `customItemImageScale` value with a default of `100`.
- Adds a **Custom Item Image Scale (%)** numeric field beside the custom item image editor input.
- Applies the configured percentage when rendering custom item images in the result, while preserving the existing 64x64 data resize cap for consistent exports.
- Clamps invalid custom item image scale values to a safe 1-200% range.
- Adds regression coverage for default, custom, invalid, and out-of-range scale behavior.

Fixes #1074.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run typecheck`
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run lint`
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npx vitest run src/components/Pokemon/TeamPokemon/__tests__/PokemonItem.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && npm run test:run`
- Playwright smoke check on `http://localhost:8080/`: expanded the Pokemon editor, set a data-URI custom item image, set scale to `50`, and confirmed the rendered `.pokemon-item img` had `width: 50%` and `height: 50%`.
