### PR TITLE
Add device image uploads

### DIFF
--- a/src/components/Common/Shared/DexieImagePickerPopover.tsx
+++ b/src/components/Common/Shared/DexieImagePickerPopover.tsx
@@ -3,6 +3,7 @@ import {
     Classes,
     IconName,
     InputGroup,
+    Intent,
     Popover,
     Position,
     Spinner,
@@ -14,8 +15,10 @@ import { toggleDialog } from "actions";
 import {
     getImagesPage,
     searchImagesByNamePrefix,
+    uploadImageFiles,
     Image as DexieImage,
 } from "./ImagesDrawer";
+import { showToast } from "./appToaster";
 
 const styles = {
     popover: css`
@@ -68,11 +71,30 @@ const styles = {
         justify-content: space-between;
         align-items: center;
         margin-top: 0.5rem;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    `,
+    footerActions: css`
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
     `,
     empty: css`
         margin-top: 0.75rem;
         color: rgba(0, 0, 0, 0.7);
         font-size: 0.9rem;
+    `,
+    uploadWrapper: css`
+        position: relative;
+        display: inline-flex;
+    `,
+    hiddenInput: css`
+        cursor: pointer;
+        opacity: 0;
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
     `,
 };
 
@@ -171,6 +193,74 @@ export function DexieImagePickerPopover({
         [onSelect],
     );
 
+    const onUploadFromDevice = React.useCallback(
+        async (e: React.ChangeEvent<HTMLInputElement>) => {
+            const files: File[] = Array.from(
+                e.target.files ?? e.currentTarget.files ?? [],
+            );
+            if (!files.length) return;
+
+            const uploadSummary = await uploadImageFiles(files);
+            const selectedImage = uploadSummary.uploaded[0];
+
+            try {
+                e.target.value = "";
+            } catch {
+                // Ignore browser-specific file input reset failures.
+            }
+
+            if (uploadSummary.uploaded.length > 0) {
+                setImages((prev) => [
+                    ...uploadSummary.uploaded.filter(
+                        (image) => (image.name ?? "").trim().length > 0,
+                    ),
+                    ...prev,
+                ]);
+                setOffset((prev) => prev + uploadSummary.uploaded.length);
+                if (selectedImage?.name) {
+                    onSelect(selectedImage.name);
+                    setIsOpen(false);
+                }
+                showToast({
+                    message:
+                        uploadSummary.uploaded.length === 1
+                            ? "Uploaded and selected image."
+                            : `Uploaded ${uploadSummary.uploaded.length} images.`,
+                    intent:
+                        uploadSummary.failed.length > 0 ||
+                        uploadSummary.tooLarge.length > 0
+                            ? Intent.WARNING
+                            : Intent.SUCCESS,
+                });
+                return;
+            }
+
+            showToast({
+                message:
+                    uploadSummary.tooLarge.length > 0
+                        ? "File size of 500KB exceeded."
+                        : "Error in parsing file.",
+                intent: Intent.DANGER,
+            });
+        },
+        [onSelect],
+    );
+
+    const uploadFromDeviceButton = (
+        <div className={styles.uploadWrapper}>
+            <Button small icon="upload">
+                Upload from Device
+            </Button>
+            <input
+                accept="image/*"
+                aria-label="Upload image from device"
+                className={styles.hiddenInput}
+                onChange={(e) => void onUploadFromDevice(e)}
+                type="file"
+            />
+        </div>
+    );
+
     const content = (
         <div className={styles.popover}>
             <div className={styles.headerRow}>
@@ -199,14 +289,16 @@ export function DexieImagePickerPopover({
             ) : images.length === 0 ? (
                 <div className={cx(styles.empty, Classes.TEXT_MUTED)}>
                     <p style={{ margin: 0 }}>No uploaded images yet.</p>
-                    <Button
-                        small
-                        icon="folder-open"
-                        onClick={openGallery}
-                        style={{ marginTop: "0.5rem" }}
-                    >
-                        Open Gallery to Upload
-                    </Button>
+                    <div className={styles.footerActions}>
+                        {uploadFromDeviceButton}
+                        <Button
+                            small
+                            icon="folder-open"
+                            onClick={openGallery}
+                        >
+                            Open Gallery
+                        </Button>
+                    </div>
                 </div>
             ) : (
                 <>
@@ -237,13 +329,16 @@ export function DexieImagePickerPopover({
                             ))}
                     </div>
                     <div className={styles.footerRow}>
-                        <Button
-                            small
-                            icon="folder-open"
-                            onClick={openGallery}
-                        >
-                            Open Gallery
-                        </Button>
+                        <div className={styles.footerActions}>
+                            {uploadFromDeviceButton}
+                            <Button
+                                small
+                                icon="folder-open"
+                                onClick={openGallery}
+                            >
+                                Open Gallery
+                            </Button>
+                        </div>
                         {hasMore ? (
                             <Button
                                 small
@@ -279,4 +374,3 @@ export function DexieImagePickerPopover({
         </Popover>
     );
 }
-

--- a/src/components/Common/Shared/ImagesDrawer.tsx
+++ b/src/components/Common/Shared/ImagesDrawer.tsx
@@ -201,6 +201,110 @@ export interface Image {
     image: string;
 }
 
+export const MAX_IMAGE_UPLOAD_SIZE_MB = 0.5;
+
+export interface UploadedImageFailure {
+    fileName: string;
+    error: unknown;
+}
+
+export interface ImageUploadSummary {
+    uploaded: Image[];
+    tooLarge: File[];
+    failed: UploadedImageFailure[];
+}
+
+const toBase64 = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            if (typeof reader.result === "string") {
+                resolve(reader.result);
+                return;
+            }
+            reject(new Error("Expected FileReader to return a data URL."));
+        };
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+
+const splitFileName = (fileName: string) => {
+    const trimmed = fileName.trim() || "uploaded-image";
+    const extensionStart = trimmed.lastIndexOf(".");
+    if (extensionStart <= 0) {
+        return {
+            baseName: trimmed,
+            extension: "",
+        };
+    }
+
+    return {
+        baseName: trimmed.slice(0, extensionStart),
+        extension: trimmed.slice(extensionStart),
+    };
+};
+
+export const getUniqueImageName = async (fileName: string) => {
+    const { baseName, extension } = splitFileName(fileName);
+    const requestedName = `${baseName}${extension}`;
+    const existing = await db.images.where("name").equals(requestedName).first();
+    if (!existing) {
+        return requestedName;
+    }
+
+    let suffix = 2;
+    while (suffix < 1000) {
+        const candidate = `${baseName} (${suffix})${extension}`;
+        const match = await db.images.where("name").equals(candidate).first();
+        if (!match) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+
+    return `${baseName} (${Date.now()})${extension}`;
+};
+
+export const uploadImageFiles = async (
+    files: File[],
+): Promise<ImageUploadSummary> => {
+    const uploaded: Image[] = [];
+    const tooLarge: File[] = [];
+    const failed: UploadedImageFailure[] = [];
+
+    for (const file of files) {
+        const size = (file.size ?? 0) / 1024 / 1024;
+        if (size > MAX_IMAGE_UPLOAD_SIZE_MB) {
+            tooLarge.push(file);
+            continue;
+        }
+        try {
+            const image = await toBase64(file);
+            const name = await getUniqueImageName(file.name);
+            const id = await db.images.add({
+                image,
+                name,
+            });
+            uploaded.push({
+                id,
+                image,
+                name,
+            });
+        } catch (error) {
+            failed.push({
+                fileName: file.name,
+                error,
+            });
+        }
+    }
+
+    return {
+        uploaded,
+        tooLarge,
+        failed,
+    };
+};
+
 enum ImagesDrawerLayout {
     List = "list",
     Grid = "grid",
@@ -284,36 +388,11 @@ export function ImagesDrawerInner() {
         const files: File[] = Array.from(e?.target?.files ?? []);
         if (!files.length) return;
 
-        const toBase64 = (file: File) =>
-            new Promise<string>((resolve, reject) => {
-                const reader = new FileReader();
-                reader.onload = () => resolve(reader.result as string);
-                reader.onerror = reject;
-                reader.readAsDataURL(file);
-            });
-
-        let uploaded = 0;
-        let tooLarge = 0;
-        let failed = 0;
-        let lastId: number | undefined;
-
-        for (const file of files) {
-            const size = (file.size ?? 0) / 1024 / 1024;
-            if (size > 0.5) {
-                tooLarge += 1;
-                continue;
-            }
-            try {
-                const image = await toBase64(file);
-                lastId = await db.images.put({
-                    image,
-                    name: file.name,
-                });
-                uploaded += 1;
-            } catch {
-                failed += 1;
-            }
-        }
+        const uploadSummary = await uploadImageFiles(files);
+        const uploaded = uploadSummary.uploaded.length;
+        const tooLarge = uploadSummary.tooLarge.length;
+        const failed = uploadSummary.failed.length;
+        const lastImage = uploadSummary.uploaded[uploaded - 1];
 
         // Allow selecting the same files again.
         try {
@@ -322,8 +401,8 @@ export function ImagesDrawerInner() {
             // ignore
         }
 
-        if (lastId != null) {
-            setRefresh(lastId);
+        if (lastImage?.id != null) {
+            setRefresh(lastImage.id);
         }
 
         const skippedText = tooLarge > 0 ? ` Skipped ${tooLarge} too-large.` : "";

--- a/src/components/Common/Shared/__tests__/DexieImagePickerPopover.test.tsx
+++ b/src/components/Common/Shared/__tests__/DexieImagePickerPopover.test.tsx
@@ -7,18 +7,27 @@ const mocks = vi.hoisted(() => {
     return {
         getImagesPage: vi.fn(),
         searchImagesByNamePrefix: vi.fn(),
+        uploadImageFiles: vi.fn(),
+        showToast: vi.fn(),
     };
 });
 
 vi.mock("components/Common/Shared/ImagesDrawer", () => ({
     getImagesPage: mocks.getImagesPage,
     searchImagesByNamePrefix: mocks.searchImagesByNamePrefix,
+    uploadImageFiles: mocks.uploadImageFiles,
+}));
+
+vi.mock("../appToaster", () => ({
+    showToast: mocks.showToast,
 }));
 
 describe("<DexieImagePickerPopover />", () => {
     beforeEach(() => {
         mocks.getImagesPage.mockReset();
         mocks.searchImagesByNamePrefix.mockReset();
+        mocks.uploadImageFiles.mockReset();
+        mocks.showToast.mockReset();
     });
 
     it("calls onSelect(name) when a thumbnail is clicked", async () => {
@@ -39,6 +48,47 @@ describe("<DexieImagePickerPopover />", () => {
 
         expect(onSelect).toHaveBeenCalledWith("my-image");
     });
+
+    it("uploads a device image and selects the stored image name", async () => {
+        mocks.getImagesPage.mockResolvedValueOnce([]);
+        mocks.uploadImageFiles.mockResolvedValueOnce({
+            uploaded: [
+                {
+                    id: 2,
+                    name: "device-image.png",
+                    image: "data:image/png;base64,abc",
+                },
+            ],
+            tooLarge: [],
+            failed: [],
+        });
+
+        const onSelect = vi.fn();
+        render(<DexieImagePickerPopover onSelect={onSelect} />);
+
+        fireEvent.click(screen.getByLabelText("Pick from uploaded images"));
+
+        await waitFor(() => {
+            expect(screen.getByText("No uploaded images yet.")).toBeDefined();
+        });
+
+        const file = new File(["image"], "device-image.png", {
+            type: "image/png",
+        });
+        const input = screen.getByLabelText(
+            "Upload image from device",
+        ) as HTMLInputElement;
+
+        fireEvent.change(input, { target: { files: [file] } });
+
+        await waitFor(() => {
+            expect(mocks.uploadImageFiles).toHaveBeenCalledWith([file]);
+            expect(onSelect).toHaveBeenCalledWith("device-image.png");
+        });
+        expect(mocks.showToast).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: "Uploaded and selected image.",
+            }),
+        );
+    });
 });
-
-

--- a/src/components/Common/Shared/__tests__/ImagesDrawer.test.ts
+++ b/src/components/Common/Shared/__tests__/ImagesDrawer.test.ts
@@ -1,0 +1,19 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { db, getUniqueImageName } from "../ImagesDrawer";
+
+describe("ImagesDrawer storage helpers", () => {
+    beforeEach(async () => {
+        await db.images.clear();
+    });
+
+    it("keeps uploaded image names unique while preserving extensions", async () => {
+        await db.images.add({
+            name: "device-image.png",
+            image: "data:image/png;base64,abc",
+        });
+
+        await expect(getUniqueImageName("device-image.png")).resolves.toBe(
+            "device-image (2).png",
+        );
+    });
+});


### PR DESCRIPTION
Fixes #846

## Summary
- Add an Upload from Device action directly inside the uploaded-image picker popover.
- Share the IndexedDB image upload path with the full Image Gallery, including duplicate filename disambiguation.
- Cover device upload selection and unique uploaded-image names with unit tests.

## Validation
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Playwright smoke check: uploaded a generated 1x1 PNG through the local Custom Image picker and verified the field value became `codex-upload.png`.
