### PR TITLE
Fix sprite centering and shiny forms

### DIFF
--- a/src/components/Features/Result/Result.css
+++ b/src/components/Features/Result/Result.css
@@ -57,6 +57,8 @@
 }
 .pokemon-image-wrapper {
     align-self: center;
+    align-items: center;
+    justify-content: center;
 }
 .logo {
     height: 2.5rem;
@@ -462,4 +464,3 @@
 .pokemon-checkpoint.obtained {
     display: flex;
 }
-

--- a/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
+++ b/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
@@ -23,32 +23,10 @@ import {
 import { selectPokemon } from "actions";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { State } from "state";
+import { getPokemonImageBackgroundStyle } from "../getPokemonImageBackgroundStyle";
 
 const spriteStyle = (style: Styles) => {
-    if (style.spritesMode) {
-        if (style.scaleSprites) {
-            return {
-                backgroundSize: "auto",
-                backgroundRepeat: "no-repeat",
-            };
-        } else {
-            return {
-                backgroundSize: "cover",
-                backgroundRepeat: "no-repeat",
-            };
-        }
-    }
-    if (style.teamImages === "dream world") {
-        return {
-            backgroundSize: "contain",
-            backgroundRepeat: "no-repeat",
-        };
-    } else {
-        return {
-            backgroundSize: "cover",
-            backgroundRepeat: "no-repeat",
-        };
-    }
+    return getPokemonImageBackgroundStyle(style);
 };
 
 export type DeadPokemonProps = {

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -29,6 +29,7 @@ import { PokemonPokeball } from "./PokemonPokeball";
 import { PokemonFriendship } from "./PokemonFriendship";
 import { normalizePokeballName } from "utils";
 import { PokemonExtraDataStats } from "./PokemonExtraDataStats";
+import { getPokemonImageBackgroundStyle } from "../getPokemonImageBackgroundStyle";
 
 export interface TeamPokemonInfoProps {
     generation: Generation;
@@ -76,33 +77,6 @@ const GameOfOriginBadge = ({
         </span>
     );
 };
-
-function getSpriteStyle({ spritesMode, scaleSprites, teamImages }) {
-    if (spritesMode) {
-        if (scaleSprites) {
-            return {
-                backgroundSize: "auto",
-                backgroundRepeat: "no-repeat",
-            };
-        } else {
-            return {
-                backgroundSize: "cover",
-                backgroundRepeat: "no-repeat",
-            };
-        }
-    }
-    if (teamImages === "dream world") {
-        return {
-            backgroundSize: "contain",
-            backgroundRepeat: "no-repeat",
-        };
-    } else {
-        return {
-            backgroundSize: "cover",
-            backgroundRepeat: "no-repeat",
-        };
-    }
-}
 
 export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
     public render() {
@@ -456,7 +430,7 @@ export class TeamPokemonBase extends React.Component<
         const getFirstType = poke.types ? poke.types[0] : "Normal";
         const getSecondType = poke.types ? poke.types[1] : "Normal";
         const { spritesMode, scaleSprites, teamImages } = style;
-        const spriteStyle = getSpriteStyle({
+        const spriteStyle = getPokemonImageBackgroundStyle({
             spritesMode,
             scaleSprites,
             teamImages,

--- a/src/components/Pokemon/__tests__/getPokemonImageBackgroundStyle.test.ts
+++ b/src/components/Pokemon/__tests__/getPokemonImageBackgroundStyle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getPokemonImageBackgroundStyle } from "../getPokemonImageBackgroundStyle";
+
+describe("getPokemonImageBackgroundStyle", () => {
+    it("centers sprite backgrounds without changing existing sizing modes", () => {
+        expect(
+            getPokemonImageBackgroundStyle({
+                spritesMode: true,
+                scaleSprites: false,
+                teamImages: "standard",
+            }),
+        ).toEqual({
+            backgroundPosition: "center center",
+            backgroundRepeat: "no-repeat",
+            backgroundSize: "cover",
+        });
+
+        expect(
+            getPokemonImageBackgroundStyle({
+                spritesMode: true,
+                scaleSprites: true,
+                teamImages: "standard",
+            }),
+        ).toEqual({
+            backgroundPosition: "center center",
+            backgroundRepeat: "no-repeat",
+            backgroundSize: "auto",
+        });
+    });
+
+    it("keeps dream world artwork contained and centered", () => {
+        expect(
+            getPokemonImageBackgroundStyle({
+                spritesMode: false,
+                scaleSprites: false,
+                teamImages: "dream world",
+            }),
+        ).toEqual({
+            backgroundPosition: "center center",
+            backgroundRepeat: "no-repeat",
+            backgroundSize: "contain",
+        });
+    });
+});

--- a/src/components/Pokemon/getPokemonImageBackgroundStyle.ts
+++ b/src/components/Pokemon/getPokemonImageBackgroundStyle.ts
@@ -1,0 +1,37 @@
+import type { CSSProperties } from "react";
+import type { Styles } from "utils";
+
+type PokemonImageBackgroundStyleOptions = Pick<
+    Styles,
+    "scaleSprites" | "spritesMode" | "teamImages"
+>;
+
+export function getPokemonImageBackgroundStyle({
+    scaleSprites,
+    spritesMode,
+    teamImages,
+}: PokemonImageBackgroundStyleOptions): CSSProperties {
+    const centeredBackgroundStyle: CSSProperties = {
+        backgroundPosition: "center center",
+        backgroundRepeat: "no-repeat",
+    };
+
+    if (spritesMode) {
+        return {
+            ...centeredBackgroundStyle,
+            backgroundSize: scaleSprites ? "auto" : "cover",
+        };
+    }
+
+    if (teamImages === "dream world") {
+        return {
+            ...centeredBackgroundStyle,
+            backgroundSize: "contain",
+        };
+    }
+
+    return {
+        ...centeredBackgroundStyle,
+        backgroundSize: "cover",
+    };
+}

--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => {
                 Unfezant: 521,
                 Gyarados: 130,
                 Dugtrio: 51,
+                Slowpoke: 79,
                 Indeedee: 876,
                 Basculegion: 902,
                 "Mime Jr.": 439,
@@ -281,6 +282,20 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             );
         });
 
+        it("keeps forme suffixes when building shiny Sword/Shield sprite URLs", async () => {
+            const result = await getPokemonImage({
+                species: "Slowpoke",
+                forme: imageForme("Galarian"),
+                name: imageGame("Sword"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: true,
+            });
+
+            expect(result).toBe(
+                "cors(https://www.serebii.net/Shiny/SWSH/079-Galarian.png)",
+            );
+        });
+
         it("uses generic serebii URL builder for other games when spritesMode is true", async () => {
             const result = await getPokemonImage({
                 species: "Pikachu",
@@ -408,4 +423,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -209,7 +209,7 @@ export async function getPokemonImage({
         } else {
             const url = `https://www.serebii.net/Shiny/${capitalize(
                 getGameNameSerebii(name as Game),
-            )}/${leadingZerosNumber}.png`;
+            )}/${leadingZerosNumber}${getForme(forme)}.png`;
 
             return await wrapImageInCORS(url);
         }
@@ -263,7 +263,7 @@ export async function getPokemonImage({
 
             return await wrapImageInCORS(url);
         }
-        const url = `https://www.serebii.net/Shiny/SWSH/${leadingZerosNumber}.png`;
+        const url = `https://www.serebii.net/Shiny/SWSH/${leadingZerosNumber}${getForme(forme)}.png`;
         return await wrapImageInCORS(url);
     }
 
@@ -271,7 +271,7 @@ export async function getPokemonImage({
         const url = shiny
             ? `https://www.serebii.net/Shiny/${getGameNameSerebii(
                   name as Game,
-              )}/${leadingZerosNumber}.png`
+              )}/${leadingZerosNumber}${getForme(forme)}.png`
             : `https://www.serebii.net/${getGameName(name as Game)}/pokemon/${leadingZerosNumber}.png`;
 
         return await wrapImageInCORS(url);


### PR DESCRIPTION
Fixes #722.

## Summary
- Center Pokémon sprite background styling consistently across team and dead Pokémon renderers.
- Center sprite image wrappers so round/square containers align their contents.
- Preserve forme suffixes for shiny Serebii sprite URLs so shiny alternate forms resolve to the matching sprite asset.

## Validation
Local validation with Node v24.11.0:
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (586 passed, 6 skipped)
- `npm run build` (Vite build warnings only)
- Headless Chromium smoke check on `localhost:8080` with round sprites + shiny Galarian Slowpoke confirmed sprite images compute centered background styles (`background-position: 50% 50%`, `background-repeat: no-repeat`, wrapper `align-items/justify-content: center`) and the shiny SWSH forme sprite URL resolves with the forme suffix (`079-g.png`).

GitHub checks are green:
- `validate`
- `check-slug-size`
- Vercel deployment
- Vercel Preview Comments
