### PR TITLE
Fix result image download height

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -32,6 +32,7 @@ import {
 } from "utils";
 
 import * as Styles from "./styles";
+import { getResultDownloadOptions } from "./downloadImage";
 
 import "./Result.css";
 import "./themes.css";
@@ -203,13 +204,21 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
 
     private async toImage() {
         const resultNode = this.resultRef.current;
+        if (!resultNode) {
+            this.setState({
+                downloadError: "Failed to download. Result image was not ready.",
+                isDownloading: false,
+            });
+            return;
+        }
+
         this.setState({ isDownloading: true });
         try {
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
-            console.log(dataUrl, resultNode);
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getResultDownloadOptions(resultNode),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -23,6 +23,10 @@ import { TrainerResult } from "./TrainerResult";
 import { getContrastColor } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
+import {
+    getResultDownloadOptions,
+    ResultDownloadOptions,
+} from "./downloadImage";
 
 import { v4 as uuid } from "uuid";
 
@@ -34,7 +38,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: ResultDownloadOptions,
     ) => Promise<string>;
 };
 
@@ -89,9 +93,10 @@ const toImage =
         try {
             setDS(DownloadStatus.active);
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getResultDownloadOptions(resultNode),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -1,9 +1,17 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { ResultBase, BackspriteMontage } from "../Result";
 import { styleDefaults, generateEmptyPokemon } from "utils";
 import { Editor, Box, Pokemon } from "models";
+
+const domToImageMock = vi.hoisted(() => ({
+    toPng: vi.fn(),
+}));
+
+vi.mock("@emmaramirez/dom-to-image", () => ({
+    domToImage: domToImageMock,
+}));
 
 type ResultBaseProps = React.ComponentProps<typeof ResultBase>;
 type PokemonSpeciesProps = { species: string };
@@ -39,8 +47,19 @@ vi.mock("components/Features/Result/TrainerResult", () => ({
 }));
 
 vi.mock("components/Layout/TopBar/TopBar", () => ({
-    TopBar: ({ children }: { children?: React.ReactNode }) => (
-        <div data-testid="top-bar">{children}</div>
+    TopBar: ({
+        children,
+        onClickDownload,
+    }: {
+        children?: React.ReactNode;
+        onClickDownload?: () => void;
+    }) => (
+        <div data-testid="top-bar">
+            <button data-testid="download-button" onClick={onClickDownload}>
+                Download
+            </button>
+            {children}
+        </div>
     ),
 }));
 
@@ -94,6 +113,15 @@ const createPokemon = () => [
 ];
 
 describe("<ResultBase />", () => {
+    beforeEach(() => {
+        domToImageMock.toPng.mockResolvedValue("data:image/png;base64,test");
+    });
+
+    afterEach(() => {
+        domToImageMock.toPng.mockReset();
+        vi.restoreAllMocks();
+    });
+
     it("renders team and status sections with rules", () => {
         render(
             <ResultBase
@@ -123,6 +151,68 @@ describe("<ResultBase />", () => {
         expect(screen.getByText("Boxed")).toBeTruthy();
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
+    });
+
+    it("expands downloaded image dimensions to include overflowing bottom rules", async () => {
+        const linkClick = vi
+            .spyOn(HTMLAnchorElement.prototype, "click")
+            .mockImplementation(() => undefined);
+        const { container } = render(
+            <ResultBase
+                pokemon={createPokemon()}
+                game={{ name: "Red", customName: "" }}
+                trainer={{ notes: "", badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    displayRules: true,
+                    displayRulesLocation: "bottom",
+                    resultHeight: 870,
+                    resultWidth: 1320,
+                    trainerSectionOrientation: "horizontal",
+                    useAutoHeight: false,
+                }}
+                rules={["Rule at the bottom of an overflowing card"]}
+                customTypes={[]}
+            />,
+        );
+
+        const resultNode = container.querySelector(".result") as HTMLElement;
+        Object.defineProperties(resultNode, {
+            clientHeight: { configurable: true, value: 870 },
+            clientWidth: { configurable: true, value: 1320 },
+            offsetHeight: { configurable: true, value: 870 },
+            offsetWidth: { configurable: true, value: 1320 },
+            scrollHeight: { configurable: true, value: 1280 },
+            scrollWidth: { configurable: true, value: 1320 },
+        });
+
+        fireEvent.click(screen.getByTestId("download-button"));
+
+        await waitFor(() => {
+            expect(domToImageMock.toPng).toHaveBeenCalledWith(resultNode, {
+                corsImage: true,
+                height: 1280,
+                width: 1320,
+                style: {
+                    height: "1280px",
+                    margin: "0",
+                    maxHeight: "none",
+                    minHeight: "1280px",
+                    minWidth: "1320px",
+                    overflow: "visible",
+                    transform: "none",
+                    width: "1320px",
+                },
+            });
+        });
+        await waitFor(() => expect(linkClick).toHaveBeenCalled());
     });
 });
 

--- a/src/components/Features/Result/downloadImage.ts
+++ b/src/components/Features/Result/downloadImage.ts
@@ -1,0 +1,56 @@
+export interface ResultDownloadOptions {
+    corsImage: boolean;
+    height: number;
+    width: number;
+    style: Record<string, string>;
+}
+
+const pixelValue = (value: string | null | undefined) => {
+    if (!value) return 0;
+
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const getRenderedSize = (
+    node: HTMLElement,
+    direction: "height" | "width",
+) => {
+    const isHeight = direction === "height";
+    const scrollSize = isHeight ? node.scrollHeight : node.scrollWidth;
+    const offsetSize = isHeight ? node.offsetHeight : node.offsetWidth;
+    const clientSize = isHeight ? node.clientHeight : node.clientWidth;
+    const inlineSize = pixelValue(
+        isHeight ? node.style.height : node.style.width,
+    );
+    const inlineMinSize = pixelValue(
+        isHeight ? node.style.minHeight : node.style.minWidth,
+    );
+
+    return Math.ceil(
+        Math.max(scrollSize, offsetSize, clientSize, inlineSize, inlineMinSize),
+    );
+};
+
+export const getResultDownloadOptions = (
+    node: HTMLElement,
+): ResultDownloadOptions => {
+    const height = getRenderedSize(node, "height");
+    const width = getRenderedSize(node, "width");
+
+    return {
+        corsImage: true,
+        height,
+        width,
+        style: {
+            height: `${height}px`,
+            margin: "0",
+            maxHeight: "none",
+            minHeight: `${height}px`,
+            minWidth: `${width}px`,
+            overflow: "visible",
+            transform: "none",
+            width: `${width}px`,
+        },
+    };
+};


### PR DESCRIPTION
## Summary
- Size result image downloads from the rendered card's full scroll dimensions instead of only the visible fixed-height box.
- Force the cloned download node to use the expanded height and visible overflow so bottom-positioned rules are included.
- Share the download sizing helper across the current result view and Result v2, with regression coverage for overflowing bottom rules.

Fixes #667.
Fixes #775.
Fixes #650.
Fixes #607.
Fixes #500.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 24 --silent && npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 24 --silent && npm run typecheck`
- `source ~/.nvm/nvm.sh && nvm use 24 --silent && npm run lint -- src/components/Features/Result/Result.tsx src/components/Features/Result/Result2.tsx src/components/Features/Result/downloadImage.ts src/components/Features/Result/__tests__/Result.test.tsx`
- Real Chromium download check against `npm run dev`: fixed-height result overflowed from 300px visible height to 445px scroll height, and the downloaded PNG was 900x445.