### PR TITLE
ART-23: Fix dead Pokémon download level wrapping

### DIFF
--- a/src/components/Features/Result/Result.css
+++ b/src/components/Features/Result/Result.css
@@ -252,6 +252,7 @@
 }
 .pokemon-levels {
     margin: 0 !important;
+    white-space: nowrap;
 }
 .trainer-container {
     background: #333;
@@ -462,4 +463,3 @@
 .pokemon-checkpoint.obtained {
     display: flex;
 }
-

--- a/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
+++ b/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
@@ -164,7 +164,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                         }}
                     >
                         <div>
-                            {poke.nickname} {GenderElement(poke.gender)} Levels{" "}
+                            {poke.nickname} {GenderElement(poke.gender)}{" "}
+                            Levels&nbsp;
                             {poke.metLevel}
                             &mdash;
                             {poke.level}
@@ -237,7 +238,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                     }}
                 >
                     <div>
-                        {poke.nickname} {GenderElement(poke.gender)} Levels{" "}
+                        {poke.nickname} {GenderElement(poke.gender)}{" "}
+                        Levels&nbsp;
                         {poke.metLevel}&mdash;
                         {poke.level}
                     </div>
@@ -319,7 +321,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                     {poke.nickname} {GenderElement(poke.gender)}
                 </div>
                 <div className="pokemon-levels">
-                    Levels {poke.metLevel}&mdash;{poke.level}
+                    Levels&nbsp;{poke.metLevel}&mdash;{poke.level}
                 </div>
                 <br />
                 <div

--- a/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
+++ b/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
@@ -14,7 +14,7 @@ const poke = {
 
 describe("<DeadPokemon />", () => {
     it("renders its content", () => {
-        render(
+        const { container } = render(
             <DeadPokemonBase
                 game={{ name: "Red", customName: "" }}
                 style={styleDefaults}
@@ -25,6 +25,9 @@ describe("<DeadPokemon />", () => {
         );
         expect(screen.getByTestId("cause-of-death").textContent).toContain(
             poke.causeOfDeath,
+        );
+        expect(container.querySelector(".pokemon-levels")?.textContent).toBe(
+            "Levels\u00a03—50",
         );
     });
 });


### PR DESCRIPTION
## Summary
- Keep the dead Pokémon level range from breaking between the `Levels` label and the level values.
- Add `white-space: nowrap` for the dead Pokémon level range used by result/download rendering.
- Cover the non-breaking level label/value text in the DeadPokemon unit test.

Fixes #437.

## Root cause
The dead Pokémon level text used normal whitespace, so the download renderer could wrap `Levels` separately from the actual level range and make the dead Pokémon box look distorted.

## Validation
- `PATH="$HOME/.nvm/versions/node/v24.11.0/bin:$PATH" npm run typecheck`
- `PATH="$HOME/.nvm/versions/node/v24.11.0/bin:$PATH" npm run lint`
- `PATH="$HOME/.nvm/versions/node/v24.11.0/bin:$PATH" npm run test:run`
- `PATH="$HOME/.nvm/versions/node/v24.11.0/bin:$PATH" npm run build`
- Playwright browser check against the GitHub #437-style state confirmed `.pokemon-levels` rendered as `Levels 4—15` with `white-space: nowrap` on one visual line.
