### PR TITLE
Support Android image downloads

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -43,6 +43,7 @@ import { resultSelector } from "selectors";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { normalizeSpeciesName } from "utils/getters/normalizeSpeciesName";
 import { Select } from "@blueprintjs/select";
+import { downloadImageDataUrl } from "utils/downloadImage";
 
 async function load() {
     const resource = await import("@emmaramirez/dom-to-image");
@@ -209,11 +210,7 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
             const dataUrl = await domToImage.toPng(resultNode, {
                 corsImage: true,
             });
-            console.log(dataUrl, resultNode);
-            const link = document.createElement("a");
-            link.download = `nuzlocke-${uuid()}.png`;
-            link.href = dataUrl;
-            link.click();
+            await downloadImageDataUrl(dataUrl, `nuzlocke-${uuid()}.png`);
             this.setState({ downloadError: null, isDownloading: false });
         } catch (e) {
             console.log(e);

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -23,6 +23,7 @@ import { TrainerResult } from "./TrainerResult";
 import { getContrastColor } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
+import { downloadImageDataUrl } from "utils/downloadImage";
 
 import { v4 as uuid } from "uuid";
 
@@ -92,10 +93,7 @@ const toImage =
             const dataUrl = await domToImage.toPng(resultNode, {
                 corsImage: true,
             });
-            const link = document.createElement("a");
-            link.download = `nuzlocke-${uuid()}.png`;
-            link.href = dataUrl;
-            link.click();
+            await downloadImageDataUrl(dataUrl, `nuzlocke-${uuid()}.png`);
             setDS(DownloadStatus.done);
         } catch (e) {
             setDS(DownloadStatus.error);

--- a/src/utils/__tests__/downloadImage.test.ts
+++ b/src/utils/__tests__/downloadImage.test.ts
@@ -1,0 +1,125 @@
+import {
+    dataUrlToBlob,
+    downloadImageDataUrl,
+    isAndroidUserAgent,
+} from "../downloadImage";
+
+describe("downloadImage", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("detects Android user agents", () => {
+        expect(isAndroidUserAgent("Mozilla/5.0 (Linux; Android 14)")).toBe(
+            true,
+        );
+        expect(isAndroidUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS)")).toBe(
+            false,
+        );
+    });
+
+    it("converts image data URLs to blobs", () => {
+        const blob = dataUrlToBlob("data:image/png;base64,aGVsbG8=");
+
+        expect(blob.type).toBe("image/png");
+        expect(blob.size).toBe(5);
+    });
+
+    it("uses Android file sharing when available", async () => {
+        const share = vi.fn().mockResolvedValue(undefined);
+        const canShare = vi.fn().mockReturnValue(true);
+        const click = vi.spyOn(HTMLAnchorElement.prototype, "click");
+
+        const result = await downloadImageDataUrl(
+            "data:image/png;base64,aGVsbG8=",
+            "nuzlocke.png",
+            {
+                navigator: {
+                    canShare,
+                    share,
+                    userAgent: "Mozilla/5.0 (Linux; Android 14)",
+                },
+            },
+        );
+
+        expect(result).toBe("shared");
+        expect(canShare).toHaveBeenCalledWith({
+            files: [expect.any(File)],
+            title: "nuzlocke.png",
+            text: "Nuzlocke result image",
+        });
+        expect(share).toHaveBeenCalledWith({
+            files: [expect.any(File)],
+            title: "nuzlocke.png",
+            text: "Nuzlocke result image",
+        });
+        expect(click).not.toHaveBeenCalled();
+    });
+
+    it("falls back to an object URL download when Android sharing fails", async () => {
+        const objectUrl = "blob:https://nuzlocke-generator.test/fallback";
+        const share = vi.fn().mockRejectedValue(new Error("Share failed"));
+        const createObjectURL = vi.fn().mockReturnValue(objectUrl);
+        const revokeObjectURL = vi.fn();
+        const setTimeout = vi.fn((callback: () => void) => {
+            callback();
+            return 1;
+        });
+        const click = vi.spyOn(HTMLAnchorElement.prototype, "click");
+
+        const result = await downloadImageDataUrl(
+            "data:image/png;base64,aGVsbG8=",
+            "nuzlocke.png",
+            {
+                navigator: {
+                    share,
+                    userAgent: "Mozilla/5.0 (Linux; Android 14)",
+                },
+                setTimeout: setTimeout as unknown as Window["setTimeout"],
+                url: { createObjectURL, revokeObjectURL },
+            },
+        );
+
+        expect(result).toBe("downloaded");
+        expect(share).toHaveBeenCalledWith({
+            files: [expect.any(File)],
+            title: "nuzlocke.png",
+            text: "Nuzlocke result image",
+        });
+        expect(click).toHaveBeenCalledTimes(1);
+        expect(revokeObjectURL).toHaveBeenCalledWith(objectUrl);
+    });
+
+    it("falls back to an object URL download", async () => {
+        const objectUrl = "blob:https://nuzlocke-generator.test/result";
+        const createObjectURL = vi.fn().mockReturnValue(objectUrl);
+        const revokeObjectURL = vi.fn();
+        const setTimeout = vi.fn((callback: () => void) => {
+            callback();
+            return 1;
+        });
+        const click = vi.spyOn(HTMLAnchorElement.prototype, "click");
+
+        const result = await downloadImageDataUrl(
+            "data:image/png;base64,aGVsbG8=",
+            "nuzlocke.png",
+            {
+                navigator: {
+                    userAgent: "Mozilla/5.0 (Linux; Android 14)",
+                },
+                setTimeout: setTimeout as unknown as Window["setTimeout"],
+                url: { createObjectURL, revokeObjectURL },
+            },
+        );
+
+        expect(result).toBe("downloaded");
+        expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+        expect(click).toHaveBeenCalledTimes(1);
+        expect(document.body.querySelector("a")).toBeNull();
+        expect(revokeObjectURL).toHaveBeenCalledWith(objectUrl);
+    });
+});

--- a/src/utils/downloadImage.ts
+++ b/src/utils/downloadImage.ts
@@ -1,0 +1,161 @@
+export type DownloadImageResult = "downloaded" | "shared";
+
+type FileShareData = {
+    files: File[];
+    title?: string;
+    text?: string;
+};
+
+type ShareNavigator = Pick<Navigator, "userAgent"> & {
+    share?: (data: FileShareData) => Promise<void>;
+    canShare?: (data: FileShareData) => boolean;
+};
+
+type DownloadImageDependencies = {
+    document?: Document;
+    fileConstructor?: typeof File;
+    navigator?: ShareNavigator;
+    setTimeout?: Window["setTimeout"];
+    url?: Pick<typeof URL, "createObjectURL" | "revokeObjectURL">;
+};
+
+const DEFAULT_IMAGE_TYPE = "image/png";
+const REVOKE_OBJECT_URL_DELAY_MS = 30_000;
+
+const isShareAbortError = (error: unknown): boolean =>
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "AbortError";
+
+export const isAndroidUserAgent = (userAgent = ""): boolean =>
+    /\bAndroid\b/i.test(userAgent);
+
+export const dataUrlToBlob = (dataUrl: string): Blob => {
+    const separatorIndex = dataUrl.indexOf(",");
+
+    if (!dataUrl.startsWith("data:") || separatorIndex === -1) {
+        throw new Error("Expected a data URL to download.");
+    }
+
+    const metadata = dataUrl.slice(5, separatorIndex);
+    const data = dataUrl.slice(separatorIndex + 1);
+    const mimeType = metadata.split(";")[0] || DEFAULT_IMAGE_TYPE;
+    const isBase64 = metadata
+        .split(";")
+        .some((part) => part.toLowerCase() === "base64");
+
+    if (!isBase64) {
+        return new Blob([decodeURIComponent(data)], { type: mimeType });
+    }
+
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+
+    return new Blob([bytes], { type: mimeType });
+};
+
+const getDownloadDependencies = (dependencies: DownloadImageDependencies) => ({
+    document: dependencies.document ?? document,
+    fileConstructor:
+        dependencies.fileConstructor ??
+        (typeof File === "undefined" ? undefined : File),
+    navigator: dependencies.navigator ?? navigator,
+    setTimeout: dependencies.setTimeout ?? window.setTimeout.bind(window),
+    url: dependencies.url ?? URL,
+});
+
+// Android browsers often ignore `download` on generated data URLs. Prefer
+// native file sharing there, then fall back to a Blob URL anchor.
+const shareImageOnAndroid = async (
+    blob: Blob,
+    filename: string,
+    dependencies: ReturnType<typeof getDownloadDependencies>,
+): Promise<boolean> => {
+    if (!isAndroidUserAgent(dependencies.navigator.userAgent)) {
+        return false;
+    }
+
+    if (!dependencies.navigator.share || !dependencies.fileConstructor) {
+        return false;
+    }
+
+    const FileConstructor = dependencies.fileConstructor;
+    const file = new FileConstructor([blob], filename, {
+        type: blob.type || DEFAULT_IMAGE_TYPE,
+    });
+    const shareData: FileShareData = {
+        files: [file],
+        title: filename,
+        text: "Nuzlocke result image",
+    };
+
+    if (dependencies.navigator.canShare) {
+        try {
+            if (!dependencies.navigator.canShare(shareData)) {
+                return false;
+            }
+        } catch {
+            return false;
+        }
+    }
+
+    try {
+        await dependencies.navigator.share(shareData);
+        return true;
+    } catch (error) {
+        if (isShareAbortError(error)) {
+            return true;
+        }
+
+        return false;
+    }
+};
+
+const downloadBlob = (
+    blob: Blob,
+    filename: string,
+    dependencies: ReturnType<typeof getDownloadDependencies>,
+): void => {
+    const objectUrl = dependencies.url.createObjectURL(blob);
+    const link = dependencies.document.createElement("a");
+
+    link.download = filename;
+    link.href = objectUrl;
+    link.rel = "noopener";
+    link.target = "_blank";
+    link.style.display = "none";
+
+    dependencies.document.body.appendChild(link);
+    link.click();
+    link.remove();
+
+    dependencies.setTimeout(() => {
+        dependencies.url.revokeObjectURL(objectUrl);
+    }, REVOKE_OBJECT_URL_DELAY_MS);
+};
+
+export const downloadImageDataUrl = async (
+    dataUrl: string,
+    filename: string,
+    dependencies: DownloadImageDependencies = {},
+): Promise<DownloadImageResult> => {
+    const resolvedDependencies = getDownloadDependencies(dependencies);
+    const blob = dataUrlToBlob(dataUrl);
+    const shared = await shareImageOnAndroid(
+        blob,
+        filename,
+        resolvedDependencies,
+    );
+
+    if (shared) {
+        return "shared";
+    }
+
+    downloadBlob(blob, filename, resolvedDependencies);
+    return "downloaded";
+};


### PR DESCRIPTION
## Summary

Fixes #732.

This fixes Android result image saving. The result renderer previously clicked a temporary `<a download>` directly against the generated data URL, which can be ignored by Android browsers and leaves users with no visible action after tapping Download Image.

The shared result image path now converts generated data URLs into Blob-backed files. On Android, it first tries the native Web Share file flow so users get the system save/share sheet. If that is unavailable or fails before a user selection, it falls back to an appended Blob URL download link with a `_blank` target, which is more reliable than clicking an unattached data URL anchor on mobile browsers. Both current result renderers now use the same helper.

## Validation

- `/bin/zsh -lc 'nvm exec 24 npm run typecheck'`
- `/bin/zsh -lc 'nvm exec 24 npm run lint'`
- `/bin/zsh -lc 'nvm exec 24 npm run test:run -- src/utils/__tests__/downloadImage.test.ts'`
- `/bin/zsh -lc 'nvm exec 24 npm run test:run'`
- `/bin/zsh -lc 'nvm exec 24 npm run build'`
