### PR TITLE
Fix clearing Met Location

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -679,7 +679,7 @@ export class CurrentPokemonEditBase extends React.Component<
                         placeholder="Pallet Town"
                         value={currentPokemon.met || ""}
                         onChange={(e) => {
-                            if (!e?.target?.value) {
+                            if (!e?.target) {
                                 return;
                             }
                             const edit = {

--- a/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
+++ b/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { fireEvent, render, screen, waitFor } from "utils/testUtils";
+import { vi } from "vitest";
+import { CurrentPokemonEditBase } from "../CurrentPokemonEdit";
+
+describe("<CurrentPokemonEdit />", () => {
+    beforeEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("allows the met location to be cleared", async () => {
+        const editPokemon = vi.fn();
+        const selectPokemon = vi.fn();
+        const selectedId = "pokemon-1";
+
+        render(
+            <CurrentPokemonEditBase
+                selectedId={selectedId}
+                box={[]}
+                pokemon={[
+                    {
+                        id: selectedId,
+                        species: "Bulbasaur",
+                        met: "Pallet Town",
+                        level: 5,
+                    },
+                ]}
+                selectPokemon={selectPokemon}
+                editPokemon={editPokemon}
+                addPokemon={vi.fn()}
+                game={{ name: "Red", customName: "" }}
+                editor={{ minimized: false }}
+                customTypes={[]}
+                customAreas={[]}
+            />,
+        );
+
+        const metLocationInput = screen
+            .getAllByTestId("autocomplete")
+            .find((input) => input.getAttribute("name") === "met");
+
+        expect(metLocationInput).toBeDefined();
+
+        fireEvent.change(metLocationInput!, { target: { value: "" } });
+
+        await waitFor(() => {
+            expect(editPokemon).toHaveBeenCalledWith({ met: "" }, selectedId);
+        });
+        expect(selectPokemon).toHaveBeenCalledWith(selectedId);
+    });
+});


### PR DESCRIPTION
## Summary
- allow the Met Location editor field to save an empty string when a user clears it
- add a regression test for clearing the Met Location autocomplete input

Fixes #1157.

## Validation
- npm run test:run -- src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx src/components/Pokemon/TeamPokemon/__tests__/getMetLocationString.test.ts
- npm run typecheck
- npm run lint -- src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
