### PR TITLE
Fix G-Max Corviknight forme

### DIFF
--- a/src/utils/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/utils.test.ts.snap
@@ -2915,7 +2915,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Corvisquire": [],
   },
   {
-    "Corviknight": [],
+    "Corviknight": [
+      "Gigantamax",
+    ],
   },
   {
     "Blipbug": [],

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -368,6 +368,10 @@ describe(matchNatureToToxtricityForme.name, () => {
 });
 
 describe(getAdditionalFormes.name, () => {
+    it("returns Gigantamax for Corviknight", () => {
+        expect(getAdditionalFormes("Corviknight")).toEqual(["Gigantamax"]);
+    });
+
     it("matches snapshot for all species", () => {
         const subject = listOfPokemon.map((species) => ({
             [species]: getAdditionalFormes(species),

--- a/src/utils/getters/getAdditionalFormes.ts
+++ b/src/utils/getters/getAdditionalFormes.ts
@@ -310,7 +310,7 @@ export const getAdditionalFormes = (species: string | undefined): string[] => {
         s === "snorlax" ||
         s === "eevee" ||
         s === "butterfree" ||
-        s === "corvinight" ||
+        s === "corviknight" ||
         s === "alcremie" ||
         s === "drednaw" ||
         s === "machamp" ||


### PR DESCRIPTION
## Summary
- fix the misspelled Corviknight key in additional forme lookup
- add a direct regression assertion that Corviknight offers Gigantamax
- update the all-species forme snapshot

Fixes #1160.

## Validation
- npm run test:run -- src/utils/__tests__/utils.test.ts
- npm run typecheck
- npm run lint -- src/utils/getters/getAdditionalFormes.ts src/utils/__tests__/utils.test.ts
