### PR TITLE
Show Gen 4 save options by default

### DIFF
--- a/src/components/Editors/DataEditor/AdvancedImportOptions.tsx
+++ b/src/components/Editors/DataEditor/AdvancedImportOptions.tsx
@@ -50,7 +50,7 @@ export const AdvancedImportOptions = React.forwardRef<
     const fileInputRef = React.useRef<HTMLInputElement>(null);
 
     const gen3Enabled = import.meta.env.VITE_GEN3_SAVES === "true";
-    const gen4Enabled = import.meta.env.VITE_GEN4_SAVES === "true";
+    const gen4Enabled = import.meta.env.VITE_GEN4_SAVES !== "false";
     const gen5Enabled = import.meta.env.VITE_GEN5_SAVES !== "false";
     
     const gen1And2Games: GameSaveFormat[] = ["RBY", "GS", "Crystal"];

--- a/src/components/Editors/DataEditor/__tests__/AdvancedImportOptions.test.tsx
+++ b/src/components/Editors/DataEditor/__tests__/AdvancedImportOptions.test.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "utils/testUtils";
+import { vi } from "vitest";
+import { AdvancedImportOptions } from "../AdvancedImportOptions";
+
+const renderAdvancedImportOptions = () =>
+    render(
+        <AdvancedImportOptions
+            boxes={[]}
+            isDarkMode={false}
+            onFileSelect={vi.fn()}
+            onShowdownImport={vi.fn()}
+        />,
+    );
+
+const getGameOptions = () => {
+    fireEvent.click(screen.getByText("Advanced Import Options"));
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    return Array.from(select.options).map((option) => option.value);
+};
+
+describe("<AdvancedImportOptions />", () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it("shows Gen 4 save formats by default", () => {
+        renderAdvancedImportOptions();
+
+        expect(getGameOptions()).toEqual(
+            expect.arrayContaining(["DP", "Platinum", "HGSS"]),
+        );
+    });
+
+    it("allows Gen 4 save formats to be explicitly disabled", () => {
+        vi.stubEnv("VITE_GEN4_SAVES", "false");
+
+        renderAdvancedImportOptions();
+
+        expect(getGameOptions()).not.toEqual(
+            expect.arrayContaining(["DP", "Platinum", "HGSS"]),
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- show Gen 4 save formats (`DP`, `Platinum`, `HGSS`) in Advanced Import Options by default
- preserve an explicit kill switch with `VITE_GEN4_SAVES=false`
- add dropdown regression coverage for default-visible and explicitly-disabled Gen 4 options

Fixes #1209.
Fixes #540.

## Validation
- `npm run test:run -- src/components/Editors/DataEditor/__tests__/AdvancedImportOptions.test.tsx`
- `npm run test:run -- src/parsers/__tests__/gen4.test.ts src/parsers/__tests__/worker.test.ts`
- `npm run typecheck`
- `npm run lint -- src/components/Editors/DataEditor/AdvancedImportOptions.tsx src/components/Editors/DataEditor/__tests__/AdvancedImportOptions.test.tsx`

## Known follow-up
- `npm run test:e2e -- e2e/gen4-save-import.spec.ts` currently fails on the existing save-import flow: after selecting `diamond.sav`, the app remains on the default one-Pokemon state instead of rendering the imported six-Pokemon party. The focused parser/worker tests pass, so this appears separate from making the manual Gen 4 options visible.