### PR TITLE
Fix undefined most common type stat

### DIFF
--- a/src/components/Features/Result/Stats.tsx
+++ b/src/components/Features/Result/Stats.tsx
@@ -37,18 +37,13 @@ export class StatsBase extends React.Component<
 
         this.props.pokemon.forEach((poke) => {
             if (poke && Array.isArray(poke.types)) {
-                const type1 = poke.types[0];
-                const type2 = poke.types[1];
+                const uniqueTypes = Array.from(
+                    new Set(poke.types.filter(Boolean)),
+                );
 
-                typesFreq[type1] = (typesFreq[type1] ?? 0) + 1;
-
-                if (Object.prototype.hasOwnProperty.call(typesFreq, type2)) {
-                    if (type1 !== type2) {
-                        typesFreq[type2] = (typesFreq[type2] ?? 0) + 1;
-                    }
-                } else {
-                    typesFreq[type2] = 1;
-                }
+                uniqueTypes.forEach((type) => {
+                    typesFreq[type] = (typesFreq[type] ?? 0) + 1;
+                });
             }
         });
 

--- a/src/components/Features/Result/__tests__/Stats.test.tsx
+++ b/src/components/Features/Result/__tests__/Stats.test.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { render, screen } from "utils/testUtils";
+import { StatsBase } from "../Stats";
+import { styleDefaults, Types } from "utils";
+
+describe("<Stats />", () => {
+    it("does not count missing secondary types as undefined", () => {
+        render(
+            <StatsBase
+                pokemon={[
+                    {
+                        id: "rattata",
+                        species: "Rattata",
+                        status: "Team",
+                        types: [Types.Normal] as unknown as [Types, Types],
+                    },
+                    {
+                        id: "pidgey",
+                        species: "Pidgey",
+                        status: "Team",
+                        types: [Types.Normal, Types.Flying],
+                    },
+                ]}
+                style={{
+                    ...styleDefaults,
+                    statsOptions: {
+                        ...styleDefaults.statsOptions,
+                        mostCommonTypes: true,
+                    },
+                }}
+                box={[]}
+                stats={[]}
+            />,
+        );
+
+        const mostCommonTypes = screen.getByText(/Most Common Types:/);
+
+        expect(mostCommonTypes.textContent).toContain(
+            "Normal (2 Pokémon), Flying (1 Pokémon)",
+        );
+        expect(mostCommonTypes.textContent).not.toContain("undefined");
+    });
+});


### PR DESCRIPTION
## Summary
- ignore missing secondary type slots when building the Most Common Types stat
- count each Pokemon's unique real types once, so duplicate mono-type tuples still only count once
- add regression coverage for imported monotype data shaped like `types: ["Normal"]`

Fixes #1139.

## Validation
- `npm run test:run -- src/components/Features/Result/__tests__/Stats.test.tsx`
- `npm run test:run -- src/parsers/__tests__/gen3.test.ts src/parsers/__tests__/gen5.test.ts`
- `npm run typecheck`
- `npm run lint -- src/components/Features/Result/Stats.tsx src/components/Features/Result/__tests__/Stats.test.tsx`
