### PR TITLE
Add missing Hisui moves

### DIFF
--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -317,6 +317,39 @@ describe(getMoveType.name, () => {
         expect(moveA).toBe(Types.Fire);
         expect(moveB).toBe(Types.Normal);
     });
+
+    it("maps Hisui moves to their types", () => {
+        const hisuiMoves: Array<[string, Types]> = [
+            ["Barb Barrage", Types.Poison],
+            ["Bitter Malice", Types.Ghost],
+            ["Bleakwind Storm", Types.Flying],
+            ["Ceaseless Edge", Types.Dark],
+            ["Chloroblast", Types.Grass],
+            ["Dire Claw", Types.Poison],
+            ["Esper Wing", Types.Psychic],
+            ["Headlong Rush", Types.Ground],
+            ["Infernal Parade", Types.Ghost],
+            ["Lunar Blessing", Types.Psychic],
+            ["Mountain Gale", Types.Ice],
+            ["Mystical Power", Types.Psychic],
+            ["Power Shift", Types.Normal],
+            ["Psyshield Bash", Types.Psychic],
+            ["Raging Fury", Types.Fire],
+            ["Sandsear Storm", Types.Ground],
+            ["Shelter", Types.Steel],
+            ["Springtide Storm", Types.Fairy],
+            ["Stone Axe", Types.Rock],
+            ["Take Heart", Types.Psychic],
+            ["Triple Arrows", Types.Fighting],
+            ["Victory Dance", Types.Fighting],
+            ["Wave Crash", Types.Water],
+            ["Wildbolt Storm", Types.Electric],
+        ];
+
+        hisuiMoves.forEach(([move, type]) => {
+            expect(getMoveType(move)).toBe(type);
+        });
+    });
 });
 
 describe(getDisplayNameForTest.name, () => {

--- a/src/utils/data/movesByType.ts
+++ b/src/utils/data/movesByType.ts
@@ -91,6 +91,7 @@ export const movesByType: MovesByType = {
         "Ruination",
         "Comeuppance",
         "Wicked Torque",
+        "Ceaseless Edge",
     ],
     Dragon: [
         "Dragon Claw",
@@ -174,6 +175,7 @@ export const movesByType: MovesByType = {
         "Electro Shot",
         "Thunderclap",
         "Supercell Slam",
+        "Wildbolt Storm",
     ],
     Fairy: [
         "Dazzling Gleam",
@@ -206,6 +208,7 @@ export const movesByType: MovesByType = {
         "Sparkly Swirl",
         "Magical Torque",
         "Alluring Voice",
+        "Springtide Storm",
     ],
     Fighting: [
         "Seismic Toss",
@@ -265,6 +268,8 @@ export const movesByType: MovesByType = {
         "Collision Course",
         "Combat Torque",
         "Upper Hand",
+        "Triple Arrows",
+        "Victory Dance",
     ],
     Fire: [
         "Fire Blast",
@@ -311,6 +316,7 @@ export const movesByType: MovesByType = {
         "Armor Cannon",
         "Blazing Torque",
         "Burning Bulwark",
+        "Raging Fury",
     ],
     Flying: [
         "FeatherDance",
@@ -343,6 +349,7 @@ export const movesByType: MovesByType = {
         "Pluck",
         "HP Flying",
         "Dual Wingbeat",
+        "Bleakwind Storm",
     ],
     Ghost: [
         "Nightmare",
@@ -376,6 +383,8 @@ export const movesByType: MovesByType = {
         "Astral Barrage",
         "Last Respects",
         "Rage Fist",
+        "Bitter Malice",
+        "Infernal Parade",
     ],
     Grass: [
         "Frenzy Plant",
@@ -434,6 +443,7 @@ export const movesByType: MovesByType = {
         "Spicy Extract",
         "Flower Trick",
         "Trailblaze",
+        "Chloroblast",
     ],
     Ground: [
         "Sand-Attack",
@@ -465,6 +475,8 @@ export const movesByType: MovesByType = {
         "Stomping Tantrum",
         "HP Ground",
         "Scorching Sands",
+        "Headlong Rush",
+        "Sandsear Storm",
     ],
     Ice: [
         "Hail",
@@ -498,6 +510,7 @@ export const movesByType: MovesByType = {
         "Ice Spinner",
         "Chilly Reception",
         "Snowscape",
+        "Mountain Gale",
     ],
     Normal: [
         "Bide",
@@ -704,6 +717,7 @@ export const movesByType: MovesByType = {
         "Tidy Up",
         "Hyper Drill",
         "Tera Sandstorm",
+        "Power Shift",
     ],
     Poison: [
         "Acid",
@@ -740,6 +754,8 @@ export const movesByType: MovesByType = {
         "Mortal Spin",
         "Noxious Torque",
         "Malignant Chain",
+        "Barb Barrage",
+        "Dire Claw",
     ],
     Psychic: [
         "Barrier",
@@ -814,6 +830,11 @@ export const movesByType: MovesByType = {
         "Lumina Crash",
         "Twin Beam",
         "Psychic Noise",
+        "Esper Wing",
+        "Lunar Blessing",
+        "Mystical Power",
+        "Psyshield Bash",
+        "Take Heart",
     ],
     Rock: [
         "Rock Throw",
@@ -839,6 +860,7 @@ export const movesByType: MovesByType = {
         "Meteor Beam",
         "Salt Cure",
         "Mighty Cleave",
+        "Stone Axe",
     ],
     Steel: [
         "Anchor Shot",
@@ -876,6 +898,7 @@ export const movesByType: MovesByType = {
         "Gigaton Hammer",
         "Hard Press",
         "Tachyon Cutter",
+        "Shelter",
     ],
     Water: [
         "Brine",
@@ -925,6 +948,7 @@ export const movesByType: MovesByType = {
         "Chilling Water",
         "Aqua Cutter",
         "Triple Dive",
+        "Wave Crash",
     ],
 
     Shadow: [


### PR DESCRIPTION
## Summary
- Adds the full Pokémon Legends: Arceus move-id block `827..850` to `movesByType`, including Headlong Rush, Wave Crash, Raging Fury, Barb Barrage, and Psyshield Bash.
- Adds `getMoveType` coverage for all 24 added Hisui moves so move coloring/type lookup stays stable.

Fixes #1152.

## Validation
- `npm run test:run -- src/utils/__tests__/utils.test.ts`
- `npm run typecheck`
- `npm run lint -- src/utils/data/movesByType.ts src/utils/__tests__/utils.test.ts`
- `npm run build`
- Husky pre-commit full `npm run lint`