### PR TITLE
Add Poltchageist evolution

### DIFF
--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -29,6 +29,7 @@ import { matchNatureToToxtricityForme } from "utils/matchNatureToToxtricityForme
 import { Nature } from "utils/Nature";
 import { getAdditionalFormes } from "utils/getters/getAdditionalFormes";
 import { getEvolutionLine } from "utils";
+import { EvolutionTree } from "utils";
 
 const objectPropertiesWhere = (
     obj: object,
@@ -373,6 +374,12 @@ describe(getAdditionalFormes.name, () => {
             [species]: getAdditionalFormes(species),
         }));
         expect(subject).toMatchSnapshot();
+    });
+});
+
+describe("EvolutionTree", () => {
+    it("includes Poltchageist evolving into Sinistcha", () => {
+        expect(EvolutionTree.Poltchageist).toEqual(["Sinistcha"]);
     });
 });
 

--- a/src/utils/data/listOfEvolutions.ts
+++ b/src/utils/data/listOfEvolutions.ts
@@ -554,6 +554,7 @@ export const EvolutionTree: EvolutionTree = {
     Glimmet: ["Glimmora"],
     Greavard: ["Houndstone"],
     Cetoddle: ["Cetitan"],
+    Poltchageist: ["Sinistcha"],
     Frigibax: ["Arctibax"],
     Arctibax: ["Baxcalibur"],
     Gimmighoul: ["Gholdengo"],


### PR DESCRIPTION
## Summary
- Adds the missing `Poltchageist -> Sinistcha` evolution data so the Pokémon editor can render the Evolve button.
- Adds a regression assertion for the static evolution table.

Fixes #1131.

## Validation
- `npm run test:run -- src/utils/__tests__/utils.test.ts`
- `npm run typecheck`
- `npm run lint -- src/utils/data/listOfEvolutions.ts src/utils/__tests__/utils.test.ts`
- `npm run build`
- Husky pre-commit full `npm run lint`