### PR TITLE
Fix regional Meowth evolution

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -99,22 +99,70 @@ export interface CurrentPokemonEditState {
     images?: Image[];
 }
 
-const getEvos = (species): string[] | undefined => {
-    return EvolutionTree?.[species];
+export interface EvolutionOption {
+    species: Species;
+    forme?: keyof typeof Forme;
+}
+
+const getFormeKey = (
+    forme?: Pokemon["forme"] | keyof typeof Forme,
+): keyof typeof Forme | undefined => {
+    if (!forme) {
+        return undefined;
+    }
+
+    if (forme in Forme) {
+        return forme as keyof typeof Forme;
+    }
+
+    return Object.entries(Forme).find(([, value]) => value === forme)?.[0] as
+        | keyof typeof Forme
+        | undefined;
+};
+
+export const getEvolutionOptions = (
+    currentPokemon?: Pick<Pokemon, "species"> & {
+        forme?: Pokemon["forme"] | keyof typeof Forme;
+    },
+): EvolutionOption[] => {
+    const species = currentPokemon?.species as Species | undefined;
+    const forme = getFormeKey(currentPokemon?.forme);
+
+    if (!species) {
+        return [];
+    }
+
+    if (species === "Meowth") {
+        if (forme === "Alolan") {
+            return [{ species: "Persian", forme: "Alolan" }];
+        }
+
+        if (forme === "Galarian") {
+            return [{ species: "Perrserker", forme: "Normal" }];
+        }
+
+        return [{ species: "Persian", forme: "Normal" }];
+    }
+
+    return (
+        EvolutionTree?.[species]?.map((evolution) => ({
+            species: evolution,
+        })) ?? []
+    );
 };
 
 export function EvolutionSelection({ currentPokemon, onEvolve }) {
-    const evos = getEvos(currentPokemon?.species);
+    const evos = getEvolutionOptions(currentPokemon);
 
     if (!evos?.length) {
         return null;
     }
 
     if (evos?.length === 1) {
-        const species = evos?.[0];
+        const { species, forme } = evos[0];
         return (
             <Button
-                onClick={onEvolve(species)}
+                onClick={onEvolve(species, forme)}
                 className={Classes.MINIMAL}
                 intent={Intent.PRIMARY}
             >
@@ -135,11 +183,11 @@ export function EvolutionSelection({ currentPokemon, onEvolve }) {
                                 role="button"
                                 tabIndex={-2}
                                 className={Styles.evoMenuItem}
-                                key={evo}
-                                onClick={onEvolve(evo)}
-                                onKeyPress={onEvolve(evo)}
+                                key={`${evo.species}-${evo.forme ?? "current"}`}
+                                onClick={onEvolve(evo.species, evo.forme)}
+                                onKeyPress={onEvolve(evo.species, evo.forme)}
                             >
-                                {evo}
+                                {evo.species}
                             </div>
                         ))}
                     </>
@@ -224,14 +272,14 @@ export class CurrentPokemonEditBase extends React.Component<
         );
     }
 
-    private evolvePokemon = (species: Species) => (_e) => {
+    private evolvePokemon =
+        (species: Species, nextForme?: keyof typeof Forme) => (_e) => {
         const pokemon = this.getCurrentPokemon();
+        const forme = nextForme || getFormeKey(pokemon?.forme) || "Normal";
         const edit = {
             species,
-            types: matchSpeciesToTypes(
-                species,
-                (pokemon?.forme || "Normal") as keyof typeof Forme,
-            ),
+            ...(nextForme ? { forme: nextForme } : {}),
+            types: matchSpeciesToTypes(species, forme as keyof typeof Forme),
         };
 
         this.props.editPokemon(edit, this.state.selectedId);

--- a/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
+++ b/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "utils/testUtils";
+import { Forme } from "utils";
+import {
+    EvolutionSelection,
+    getEvolutionOptions,
+} from "../CurrentPokemonEdit";
+
+describe(getEvolutionOptions.name, () => {
+    it("maps Alolan Meowth to Alolan Persian", () => {
+        const options = getEvolutionOptions({
+            species: "Meowth",
+            forme: "Alolan",
+        });
+
+        expect(options).toEqual([{ species: "Persian", forme: "Alolan" }]);
+    });
+
+    it("maps enum-valued Alolan Meowth to Alolan Persian", () => {
+        const options = getEvolutionOptions({
+            species: "Meowth",
+            forme: Forme.Alolan,
+        });
+
+        expect(options).toEqual([{ species: "Persian", forme: "Alolan" }]);
+    });
+
+    it("maps Galarian Meowth to Perrserker without a regional forme", () => {
+        const options = getEvolutionOptions({
+            species: "Meowth",
+            forme: "Galarian",
+        });
+
+        expect(options).toEqual([{ species: "Perrserker", forme: "Normal" }]);
+    });
+
+    it("maps regular Meowth to regular Persian", () => {
+        const options = getEvolutionOptions({
+            species: "Meowth",
+            forme: "Normal",
+        });
+
+        expect(options).toEqual([{ species: "Persian", forme: "Normal" }]);
+    });
+});
+
+describe(EvolutionSelection.name, () => {
+    it("evolves Alolan Meowth into Alolan Persian", () => {
+        const handleEvolve = vi.fn(() => vi.fn());
+
+        render(
+            <EvolutionSelection
+                currentPokemon={{ species: "Meowth", forme: "Alolan" }}
+                onEvolve={handleEvolve}
+            />,
+        );
+
+        fireEvent.click(screen.getByText("Evolve"));
+
+        expect(handleEvolve).toHaveBeenCalledWith("Persian", "Alolan");
+    });
+
+    it("evolves Galarian Meowth into regular Perrserker", () => {
+        const handleEvolve = vi.fn(() => vi.fn());
+
+        render(
+            <EvolutionSelection
+                currentPokemon={{ species: "Meowth", forme: "Galarian" }}
+                onEvolve={handleEvolve}
+            />,
+        );
+
+        fireEvent.click(screen.getByText("Evolve"));
+
+        expect(handleEvolve).toHaveBeenCalledWith("Perrserker", "Normal");
+    });
+});


### PR DESCRIPTION
## Summary
- Makes the Evolve button resolve Meowth evolutions with forme context.
- Alolan Meowth now evolves to Alolan Persian, Galarian Meowth evolves to regular Perrserker, and regular Meowth evolves to regular Persian.
- Adds focused helper/component coverage for string and enum-valued formes.

Fixes #1123.

## Validation
- `npm run test:run -- src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx`
- `npm run typecheck`
- `npm run lint -- src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx`
- `npm run build`
- Husky pre-commit full `npm run lint`