### PR TITLE
[codex] Fix Pokémon spelling in visible UI

### DIFF
--- a/src/components/Common/Shared/ImagesDrawer.tsx
+++ b/src/components/Common/Shared/ImagesDrawer.tsx
@@ -395,7 +395,7 @@ export function ImagesDrawerInner() {
                     <NonIdealState
                         icon="media"
                         title="No images uploaded"
-                        description="Upload images to use as custom Pokemon artwork"
+                        description="Upload images to use as custom Pokémon artwork"
                     />
                 )}
                 {images?.map((image) => (

--- a/src/components/Editors/BaseEditor/BaseEditor.tsx
+++ b/src/components/Editors/BaseEditor/BaseEditor.tsx
@@ -8,6 +8,7 @@ export interface BaseEditorState {
 export interface BaseEditorProps {
     name: string;
     icon?: IconName;
+    className?: string;
     defaultOpen?: boolean;
     children?: React.ReactNode;
 }
@@ -29,10 +30,14 @@ export class BaseEditor extends React.Component<
     };
 
     public render() {
+        const className =
+            this.props.className ??
+            `${this.props.name.toLowerCase().replace(/\s/g, "-")}-editor`;
+
         return (
             <div
                 data-testid="base-editor"
-                className={`${this.props.name.toLowerCase().replace(/\s/g, "-")}-editor base-editor`}
+                className={`${className} base-editor`}
             >
                 <h4
                     title={`${this.state.isOpen ? "Collapse" : "Open"} this editor.`}

--- a/src/components/Editors/BaseEditor/__tests__/BaseEditor.test.tsx
+++ b/src/components/Editors/BaseEditor/__tests__/BaseEditor.test.tsx
@@ -20,4 +20,11 @@ describe("<BaseEditor />", () => {
         );
         expect(screen.findByText("Hello World!")).toBeDefined();
     });
+
+    it("can keep a stable class name separate from its display name", () => {
+        render(<BaseEditor name="Pokémon" className="pokemon-editor" />);
+        const editor = screen.getByTestId("base-editor");
+        expect(editor.className).toContain("pokemon-editor");
+        expect(editor.textContent).toContain("Pokémon");
+    });
 });

--- a/src/components/Editors/DataEditor/DataEditor.tsx
+++ b/src/components/Editors/DataEditor/DataEditor.tsx
@@ -612,7 +612,7 @@ export class DataEditorBase extends React.Component<
 
         if (newPokemon.length === 0) {
             showToast({
-                message: "No Pokemon found in the input.",
+                message: "No Pokémon found in the input.",
                 intent: Intent.WARNING,
             });
             return;
@@ -624,7 +624,7 @@ export class DataEditorBase extends React.Component<
         replaceState(newState);
 
         showToast({
-            message: `Imported ${newPokemon.length} Pokemon from Showdown format!`,
+            message: `Imported ${newPokemon.length} Pokémon from Showdown format!`,
             intent: Intent.SUCCESS,
         });
 
@@ -658,7 +658,7 @@ export class DataEditorBase extends React.Component<
                 }}
             >
                 <div style={{ marginBottom: "0.5rem", fontWeight: 500 }}>
-                    Preview: {pokemon.length} Pokemon found
+                    Preview: {pokemon.length} Pokémon found
                 </div>
                 <div style={{ display: "flex", flexWrap: "wrap", gap: "0.25rem" }}>
                     {pokemon.map((p) => (
@@ -822,7 +822,7 @@ export class DataEditorBase extends React.Component<
                         )}
                     >
                         <Callout intent={Intent.PRIMARY} style={{ marginBottom: "0.5rem" }}>
-                            Paste your Pokemon Showdown format text below. Each Pokemon
+                            Paste your Pokémon Showdown format text below. Each Pokémon
                             will be added to your Team.
                         </Callout>
                         <div style={{ marginBottom: "0.5rem", display: "flex", alignItems: "center", gap: "0.5rem" }}>
@@ -876,7 +876,7 @@ export class DataEditorBase extends React.Component<
                                 onClick={this.confirmShowdownImport}
                                 disabled={this.state.showdownData.trim() === ""}
                             >
-                                Import Pokemon
+                                Import Pokémon
                             </Button>
                         </div>
                     </div>

--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -50,6 +50,11 @@ import { normalizePokeballName } from "utils";
 
 const pokeball = "./assets/pokeball.png";
 
+const formatPokeballOption = (ball: string) => {
+    const label = `${ball.charAt(0).toUpperCase() + ball.slice(1)} Ball`;
+    return normalizePokeballName(label) ?? label;
+};
+
 export interface CopyPokemonButtonProps {
     onClick: (event: React.MouseEvent<HTMLElement>) => void;
 }
@@ -68,7 +73,7 @@ export const CopyPokemonButton: React.FunctionComponent<
             }
         >
             <Icon
-                title="Copy Pokemon"
+                title="Copy Pokémon"
                 icon="duplicate"
                 className={cx(Styles.copyButton)}
                 onClick={onClick}
@@ -461,10 +466,7 @@ export class CurrentPokemonEditBase extends React.Component<
                     type="select"
                     options={[
                         "None",
-                        ...listOfPokeballs.map(
-                            (ball) =>
-                                `${ball.charAt(0).toUpperCase() + ball.slice(1, ball.length)} Ball`,
-                        ),
+                        ...listOfPokeballs.map(formatPokeballOption),
                     ]}
                     key={this.state.selectedId + "ball"}
                 />

--- a/src/components/Editors/PokemonEditor/PokemonEditor.tsx
+++ b/src/components/Editors/PokemonEditor/PokemonEditor.tsx
@@ -143,7 +143,11 @@ export class PokemonEditorBase extends React.Component<
 
         return (
             <>
-                <BaseEditor icon="circle" name="Pokemon">
+                <BaseEditor
+                    className="pokemon-editor"
+                    icon="circle"
+                    name="Pokémon"
+                >
                     <div
                         data-testid="pokemon-editor"
                         className="button-row"

--- a/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
+++ b/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
@@ -312,7 +312,7 @@ export const PokemonLocationChecklist = ({
                 style={{ fontSize: "80%", marginTop: "0.5rem" }}
             >
                 Tip: Pokémon with the &quot;hidden&quot; attribute are a great
-                option for including Pokemon that got away on a certain route!
+                option for including Pokémon that got away on a certain route!
             </Callout>
         </div>
     );

--- a/src/components/Editors/PokemonEditor/PokemonNotes.tsx
+++ b/src/components/Editors/PokemonEditor/PokemonNotes.tsx
@@ -1,4 +1,4 @@
 import * as React from "react";
 
 // @TODO finish pokemon notes editor
-export const PokemonNotes = () => <div>Pokemon Notes Editor</div>;
+export const PokemonNotes = () => <div>Pokémon Notes Editor</div>;

--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -618,7 +618,7 @@ export class StyleEditorBase extends React.Component<
                         htmlFor="boxedPokemonPerLine"
                         className={cx(Classes.LABEL, Classes.INLINE)}
                     >
-                        Pokemon Per Line (Boxed)
+                        Pokémon Per Line (Boxed)
                     </label>
                     <input
                         name="boxedPokemonPerLine"
@@ -637,7 +637,7 @@ export class StyleEditorBase extends React.Component<
                         htmlFor="linkedPokemonText"
                         className={cx(Classes.LABEL, Classes.INLINE)}
                     >
-                        Linked Pokemon Text
+                        Linked Pokémon Text
                     </label>
                     <input
                         name="linkedPokemonText"

--- a/src/components/Editors/ThemeEditor/ThemeEditor.tsx
+++ b/src/components/Editors/ThemeEditor/ThemeEditor.tsx
@@ -129,7 +129,7 @@ const componentTree: ComponentNode[] = [
         id: 8,
         icon: "style",
         isExpanded: true,
-        label: "Team Pokemon",
+        label: "Team Pokémon",
         component: TeamPokemon,
         options: {
             props: {
@@ -150,7 +150,7 @@ const componentTree: ComponentNode[] = [
         id: 91,
         icon: "style",
         isExpanded: true,
-        label: "Boxed Pokemon",
+        label: "Boxed Pokémon",
         component: BoxedPokemon,
         options: {
             props: {},
@@ -163,7 +163,7 @@ const componentTree: ComponentNode[] = [
         id: 10,
         icon: "style",
         isExpanded: true,
-        label: "Dead Pokemon",
+        label: "Dead Pokémon",
         component: DeadPokemon,
         options: {
             props: {
@@ -179,7 +179,7 @@ const componentTree: ComponentNode[] = [
         id: 9,
         icon: "style",
         isExpanded: true,
-        label: "Champs Pokemon Collection",
+        label: "Champs Pokémon Collection",
         component: ChampsPokemonView,
         options: {
             props: {
@@ -196,7 +196,7 @@ const componentTree: ComponentNode[] = [
             {
                 id: 12,
                 isExpanded: true,
-                label: "Champs Pokemon",
+                label: "Champs Pokémon",
                 component: ChampsPokemon,
                 options: {
                     props: {

--- a/src/components/Layout/App/DebugDialog.tsx
+++ b/src/components/Layout/App/DebugDialog.tsx
@@ -43,7 +43,7 @@ export const DebugDialog: React.FC<DebugDialogProps> = ({
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
                 <Button fill onClick={onAddRandomPokemon}>
-                    Add Random Pokemon
+                    Add Random Pokémon
                 </Button>
                 <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
                     <Button 
@@ -66,4 +66,3 @@ export const DebugDialog: React.FC<DebugDialogProps> = ({
         </div>
     );
 };
-

--- a/src/components/Pokemon/DeletePokemonButton/DeletePokemonButton.tsx
+++ b/src/components/Pokemon/DeletePokemonButton/DeletePokemonButton.tsx
@@ -59,12 +59,12 @@ export class DeletePokemonButtonBase extends React.Component<
                         }
                         this.toggleDialog();
                     }}
-                    confirmButtonText="Delete Pokemon"
+                    confirmButtonText="Delete Pokémon"
                     cancelButtonText="Cancel"
                     intent={Intent.DANGER}
                 >
                     <p>
-                        This will delete the currently selected Pokemon. Are you
+                        This will delete the currently selected Pokémon. Are you
                         sure you want to do that?
                     </p>
 
@@ -102,7 +102,7 @@ export class DeletePokemonButtonBase extends React.Component<
                             }
                         }}
                         icon="trash"
-                        title="Delete Pokemon"
+                        title="Delete Pokémon"
                     />
                 </Popover>
             </div>

--- a/src/parsers/utils/gen3.ts
+++ b/src/parsers/utils/gen3.ts
@@ -11,7 +11,7 @@ export const GEN_3_HELD_ITEM_MAP: Record<number, string | undefined> = {
     1: "Master Ball",
     2: "Ultra Ball",
     3: "Great Ball",
-    4: "Poke Ball",
+    4: "Poké Ball",
     5: "Safari Ball",
     6: "Net Ball",
     7: "Dive Ball",

--- a/src/reducers/__tests__/rules.test.ts
+++ b/src/reducers/__tests__/rules.test.ts
@@ -11,7 +11,7 @@ import {
 
 const initialRules = [
     "Each Pokémon that faints is considered dead and must be released or permaboxed",
-    "You can only catch the first Pokemon you encounter in an area",
+    "You can only catch the first Pokémon you encounter in an area",
     "All Pokémon must be nicknamed",
 ];
 

--- a/src/reducers/rules.ts
+++ b/src/reducers/rules.ts
@@ -11,7 +11,7 @@ import {
 
 const initialState = [
     "Each Pokémon that faints is considered dead and must be released or permaboxed",
-    "You can only catch the first Pokemon you encounter in an area",
+    "You can only catch the first Pokémon you encounter in an area",
     "All Pokémon must be nicknamed",
 ];
 

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -10,6 +10,8 @@ import {
     Generation,
     typeToColor,
     isEmpty,
+    normalizePokeballName,
+    formatBallText,
 } from "utils";
 import * as React from "react";
 import * as Color from "color";
@@ -69,6 +71,18 @@ describe("isEmpty", () => {
 
     it("works with empty arrays", () => {
         expect(isEmpty([])).toBe(true);
+    });
+});
+
+describe("pokeball formatters", () => {
+    it("uses official Poké Ball display text", () => {
+        expect(normalizePokeballName("Poke Ball")).toBe("Poké Ball");
+        expect(normalizePokeballName("Poké Ball")).toBe("Poké Ball");
+    });
+
+    it("keeps the Poké Ball icon key ASCII", () => {
+        expect(formatBallText("Poké Ball")).toBe("poke");
+        expect(formatBallText("Poke Ball")).toBe("poke");
     });
 });
 

--- a/src/utils/data/listOfItems.ts
+++ b/src/utils/data/listOfItems.ts
@@ -288,7 +288,7 @@ export const listOfItems = [
     "Pack of Potatoes",
     "Packaged Curry",
     "Pasta",
-    "Pokemon Box Link",
+    "Pokémon Box Link",
     "Precooked Burger",
     "Pungent Root",
     "Quiet Mint",

--- a/src/utils/formatters/formatBallText.ts
+++ b/src/utils/formatters/formatBallText.ts
@@ -2,5 +2,12 @@ import { normalizePokeballName } from "./normalizePokeballName";
 
 export const formatBallText = (b: string) => {
     const normalized = normalizePokeballName(b);
-    return normalized && normalized.replace(/\s*Ball$/i, "").toLowerCase();
+    return (
+        normalized &&
+        normalized
+            .normalize("NFD")
+            .replace(/[\u0300-\u036f]/g, "")
+            .replace(/\s*Ball$/i, "")
+            .toLowerCase()
+    );
 };

--- a/src/utils/formatters/normalizePokeballName.ts
+++ b/src/utils/formatters/normalizePokeballName.ts
@@ -6,9 +6,8 @@ export const normalizePokeballName = (name?: string | null) => {
         .normalize("NFD")
         .replace(/[\u0300-\u036f]/g, "");
 
-    if (ascii.toLowerCase() === "poke ball") return "Poke Ball";
+    if (ascii.toLowerCase() === "poke ball") return "Poké Ball";
 
     return ascii;
 };
-
 


### PR DESCRIPTION
## Summary

Fixes #1076.

Updates user-visible spelling from `Pokemon`/`Poke Ball` to `Pokémon`/`Poké Ball` across the editor UI, default rule text, Showdown import copy, theme/style labels, item names, and Gen 3 held item display.

The Poké Ball display normalizer now returns the accented label, while `formatBallText` strips diacritics before building the icon key so existing `poke` assets still resolve. `BaseEditor` also accepts a stable class name override so the Pokémon editor heading can display the accented name without changing the existing `pokemon-editor` class hook.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Playwright smoke on `http://localhost:18080/`: verified the editor heading renders `Pokémon` and the expanded Poké Ball select includes `Poké Ball`.