### PR TITLE
[codex] Fix result color adjustment in preview

### DIFF
--- a/src/components/Features/Result/Result.css
+++ b/src/components/Features/Result/Result.css
@@ -19,6 +19,10 @@
     width: 100%;
     height: 100%;
 }
+.result.ng-container {
+    color-scheme: only light;
+    forced-color-adjust: none;
+}
 .ng-container h3 {
     text-transform: uppercase;
     margin: 0.5rem;


### PR DESCRIPTION
Fixes #1202

## Summary
- opt the rendered result container into a light-only color scheme
- disable forced color adjustment on the result preview so browser dark/forced-color handling does not invert the live page borders/colors while keeping exports unchanged

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Playwright smoke on the reported sprite-mode LeafGreen-style state confirmed `.result.ng-container` computes `color-scheme: light only`, `forced-color-adjust: none`, and preserves the expected light result/header colors.