### PR TITLE
[codex] Preserve Nuzlocke save order

### DIFF
--- a/src/components/Editors/SavesEditor/NuzlockeSave.tsx
+++ b/src/components/Editors/SavesEditor/NuzlockeSave.tsx
@@ -50,11 +50,6 @@ export interface NuzlockeSaveControlsState {
     deletionFunction?: () => void;
 }
 
-const sort = (
-    a: State["nuzlockes"]["saves"][number],
-    b: State["nuzlockes"]["saves"][number],
-) => a.id.localeCompare(b.id);
-
 const stripEditorDarkModeFromState = (state: State) => {
     const baseState = omit(["nuzlockes", "editorHistory"], state) as {
         style?: Styles;
@@ -110,7 +105,7 @@ export class NuzlockeSaveBase extends React.Component<
         const { nuzlockes } = this.props;
         const { currentId } = this.props.nuzlockes;
         const { isHofOpen, isDeletingNuzlocke, deletionFunction } = this.state;
-        const saves = nuzlockes.saves.sort(sort);
+        const saves = nuzlockes.saves;
 
         return (
             <div
@@ -143,7 +138,6 @@ export class NuzlockeSaveBase extends React.Component<
                 </Button>
                 {saves.map((nuzlocke) => {
                     const id = nuzlocke.id;
-                    console.log(nuzlocke.id);
                     const { isCopy } = nuzlocke;
                     const isCurrent = currentId === id;
                     const data = nuzlocke.data;

--- a/src/reducers/__tests__/nuzlocke.test.ts
+++ b/src/reducers/__tests__/nuzlocke.test.ts
@@ -1,0 +1,54 @@
+import {
+    newNuzlocke,
+    updateNuzlocke,
+    updateSwitchNuzlocke,
+} from "actions";
+import { nuzlockes, Nuzlockes } from "../nuzlocke";
+
+describe("nuzlockes", () => {
+    const savedRuns: Nuzlockes = {
+        currentId: "run-a",
+        saves: [
+            { id: "run-a", data: "red" },
+            { id: "run-b", data: "blue", isCopy: true },
+            { id: "run-c", data: "yellow" },
+        ],
+    };
+
+    it("appends new nuzlockes in creation order", () => {
+        const first = nuzlockes(undefined, newNuzlocke("red", { isCopy: false }));
+        const second = nuzlockes(first, newNuzlocke("blue", { isCopy: false }));
+
+        expect(second.saves.map((save) => save.data)).toEqual(["red", "blue"]);
+    });
+
+    it("updates a saved nuzlocke without changing list order", () => {
+        const result = nuzlockes(savedRuns, updateNuzlocke("run-b", "silver"));
+
+        expect(result.saves.map((save) => save.id)).toEqual([
+            "run-a",
+            "run-b",
+            "run-c",
+        ]);
+        expect(result.saves[1]).toEqual({
+            id: "run-b",
+            data: "silver",
+            isCopy: true,
+        });
+    });
+
+    it("keeps save order when switching away from the current nuzlocke", () => {
+        const result = nuzlockes(
+            savedRuns,
+            updateSwitchNuzlocke("run-a", "run-c", "crystal"),
+        );
+
+        expect(result.currentId).toBe("run-c");
+        expect(result.saves.map((save) => save.id)).toEqual([
+            "run-a",
+            "run-b",
+            "run-c",
+        ]);
+        expect(result.saves[0].data).toBe("crystal");
+    });
+});

--- a/src/reducers/nuzlocke.ts
+++ b/src/reducers/nuzlocke.ts
@@ -19,6 +19,32 @@ export interface Nuzlockes {
     saves: NuzlockeSaveEntry[];
 }
 
+const updateSaveInPlace = (
+    saves: NuzlockeSaveEntry[],
+    id: string,
+    data: string,
+): NuzlockeSaveEntry[] => {
+    const index = saves.findIndex((save) => save.id === id);
+    if (index === -1) {
+        return [
+            ...saves,
+            {
+                id,
+                data,
+            },
+        ];
+    }
+
+    return saves.map((save, saveIndex) =>
+        saveIndex === index
+            ? {
+                  ...save,
+                  data,
+              }
+            : save,
+    );
+};
+
 export function nuzlockes(
     state: Nuzlockes = {
         currentId: "",
@@ -63,13 +89,7 @@ export function nuzlockes(
             return {
                 ...state,
                 currentId: action.newId,
-                saves: [
-                    ...state.saves.filter((s) => s.id !== action.id),
-                    {
-                        id: action.id,
-                        data: action.data,
-                    },
-                ],
+                saves: updateSaveInPlace(state.saves, action.id, action.data),
             };
         case UPDATE_NUZLOCKE:
             // const updateItem = state.saves.find(s => s.id === action.id);
@@ -89,13 +109,7 @@ export function nuzlockes(
             // }
             return {
                 ...state,
-                saves: [
-                    ...state.saves.filter((s) => s.id !== action.id),
-                    {
-                        id: action.id,
-                        data: action.data,
-                    },
-                ],
+                saves: updateSaveInPlace(state.saves, action.id, action.data),
             };
         default:
             return state;


### PR DESCRIPTION
Fixes #1201

## Summary
- stop sorting the Saves list by random UUIDs, so imported/created saves render in persisted order
- update existing saved Nuzlockes in place instead of removing and appending them during save/switch flows
- preserve existing save metadata like `isCopy` when updating saved data
- add reducer coverage for creation order, update order, and switch-save order

## Validation
- `npm run test:run -- src/reducers/__tests__/nuzlocke.test.ts`
- `npm run typecheck`
- `npm run lint -- src/reducers/nuzlocke.ts src/reducers/__tests__/nuzlocke.test.ts src/components/Editors/SavesEditor/NuzlockeSave.tsx`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- Browser smoke on `http://localhost:18082/`: seeded three saves with deliberately non-sorted UUIDs and confirmed the Saves UI rendered them in persisted array order.