### PR TITLE
[codex] Split team and boxed origin backgrounds

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -819,8 +819,14 @@ export class StyleEditorBase extends React.Component<
                     <Checkbox
                         checked={props.style.displayBackgroundInsteadOfBadge}
                         name="displayBackgroundInsteadOfBadge"
-                        label="Display Background Color Instead of Badge"
+                        label="Display Boxed Background Color Instead of Badge"
                         onChange={(e) => editCheckboxEvent(e, props, "displayBackgroundInsteadOfBadge")}
+                    />
+                    <Checkbox
+                        checked={props.style.displayTeamBackgroundInsteadOfBadge}
+                        name="displayTeamBackgroundInsteadOfBadge"
+                        label="Display Team Background Color Instead of Badge"
+                        onChange={(e) => editCheckboxEvent(e, props, "displayTeamBackgroundInsteadOfBadge")}
                     />
                 </div>
 

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -39,6 +39,21 @@ export interface TeamPokemonInfoProps {
     game: State["game"];
 }
 
+const usesGameOfOriginBackground = (pokemon: Pokemon, style: Styles) => {
+    if (
+        !style.displayGameOriginForBoxedAndDead ||
+        !pokemon.gameOfOrigin ||
+        pokemon.gameOfOrigin === "None" ||
+        !gameOfOriginToColor(pokemon.gameOfOrigin)
+    ) {
+        return false;
+    }
+
+    return pokemon.status === "Team"
+        ? Boolean(style.displayTeamBackgroundInsteadOfBadge)
+        : Boolean(style.displayBackgroundInsteadOfBadge);
+};
+
 const GameOfOriginBadge = ({
     pokemon,
     style,
@@ -48,7 +63,7 @@ const GameOfOriginBadge = ({
 }) => {
     if (
         !style.displayGameOriginForBoxedAndDead ||
-        style.displayBackgroundInsteadOfBadge ||
+        usesGameOfOriginBackground(pokemon, style) ||
         !pokemon.gameOfOrigin ||
         pokemon.gameOfOrigin === "None"
     ) {
@@ -119,10 +134,9 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
         const gameOfOriginColor = pokemon.gameOfOrigin
             ? gameOfOriginToColor(pokemon.gameOfOrigin)
             : "";
-        const useGameOfOriginBackground = Boolean(
-            style.displayGameOriginForBoxedAndDead &&
-                style.displayBackgroundInsteadOfBadge &&
-                gameOfOriginColor,
+        const useGameOfOriginBackground = usesGameOfOriginBackground(
+            pokemon,
+            style,
         );
         const isCompactTheme =
             style.template === TemplateName.Compact ||

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
@@ -334,4 +334,88 @@ describe("TeamPokemonInfo", () => {
             "White 2",
         );
     });
+
+    it("keeps team game origin as a badge when only boxed background is enabled", () => {
+        const styleWithBoxedBackground = {
+            ...baseStyle,
+            displayGameOriginForBoxedAndDead: true,
+            displayBackgroundInsteadOfBadge: true,
+        };
+
+        render(
+            <TeamPokemonInfo
+                generation={Generation.Gen5}
+                style={styleWithBoxedBackground}
+                pokemon={{
+                    ...basePokemon,
+                    status: "Team",
+                    gameOfOrigin: "White 2",
+                }}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        expect(screen.getByTestId("pokemon-gameoforigin").textContent).toBe(
+            "White 2",
+        );
+    });
+
+    it("uses game origin background for boxed pokemon when boxed background is enabled", () => {
+        const styleWithBoxedBackground = {
+            ...baseStyle,
+            displayGameOriginForBoxedAndDead: true,
+            displayBackgroundInsteadOfBadge: true,
+        };
+        const { container } = render(
+            <TeamPokemonInfo
+                generation={Generation.Gen5}
+                style={styleWithBoxedBackground}
+                pokemon={{
+                    ...basePokemon,
+                    status: "Boxed",
+                    gameOfOrigin: "White 2",
+                }}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        expect(screen.queryByTestId("pokemon-gameoforigin")).toBeNull();
+        expect(
+            (container.querySelector(".pokemon-info") as HTMLElement).style
+                .backgroundColor,
+        ).toBe("rgb(242, 232, 232)");
+    });
+
+    it("uses game origin background for team pokemon only when team background is enabled", () => {
+        const styleWithTeamBackground = {
+            ...baseStyle,
+            displayGameOriginForBoxedAndDead: true,
+            displayBackgroundInsteadOfBadge: true,
+            displayTeamBackgroundInsteadOfBadge: true,
+        };
+        const { container } = render(
+            <TeamPokemonInfo
+                generation={Generation.Gen5}
+                style={styleWithTeamBackground}
+                pokemon={{
+                    ...basePokemon,
+                    status: "Team",
+                    gameOfOrigin: "White 2",
+                }}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        expect(screen.queryByTestId("pokemon-gameoforigin")).toBeNull();
+        expect(
+            (container.querySelector(".pokemon-info") as HTMLElement).style
+                .backgroundColor,
+        ).toBe("rgb(242, 232, 232)");
+    });
 });

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -58,6 +58,7 @@ export interface Styles {
     boxedPokemonPerLine: number;
     displayGameOriginForBoxedAndDead: boolean;
     displayBackgroundInsteadOfBadge: boolean;
+    displayTeamBackgroundInsteadOfBadge: boolean;
     displayExtraData: boolean;
     useAutoHeight: boolean;
     displayItemAsText: boolean;
@@ -106,6 +107,7 @@ export const styleDefaults: Styles = {
     boxedPokemonPerLine: 6,
     displayGameOriginForBoxedAndDead: false,
     displayBackgroundInsteadOfBadge: false,
+    displayTeamBackgroundInsteadOfBadge: false,
     displayExtraData: true,
     useAutoHeight: true,
     usePokemonGBAFont: false,


### PR DESCRIPTION
Fixes #1195

## Summary
- split the game-origin background option into boxed/non-team and team-specific toggles
- keep the existing `displayBackgroundInsteadOfBadge` setting for boxed/dead/champs Pokémon
- add `displayTeamBackgroundInsteadOfBadge`, defaulting off, so Team Pokémon keep the game-origin badge unless explicitly enabled
- update Team Pokémon rendering so the badge is only hidden when that specific Pokémon status is using the background color
- add regression coverage for boxed background behavior, team badge behavior, and team background opt-in behavior

## Validation
- `npm run test:run -- src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- Browser smoke on `http://localhost:18083/`: confirmed both Style editor controls are visible and the Team background toggle defaults off.