### PR TITLE
Add separate Pokemon extra notes

### DIFF
--- a/src/components/Editors/DataEditor/DataEditor.tsx
+++ b/src/components/Editors/DataEditor/DataEditor.tsx
@@ -575,7 +575,10 @@ export class DataEditorBase extends React.Component<
         const hasNoMoves = !pokemon.moves || pokemon.moves.length === 0;
         const hasNoAbility = !pokemon.ability;
         const hasNoCustomizations =
-            !pokemon.customImage && !pokemon.customIcon && !pokemon.notes;
+            !pokemon.customImage &&
+            !pokemon.customIcon &&
+            !pokemon.notes &&
+            !pokemon.extraNotes;
 
         return (
             isSpeciesEmpty &&

--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -525,6 +525,13 @@ export class CurrentPokemonEditBase extends React.Component<
                         type="textArea"
                         key={this.state.selectedId + "notes"}
                     />
+                    <CurrentPokemonInput
+                        labelName="Extra Notes"
+                        inputName="extraNotes"
+                        value={currentPokemon.extraNotes}
+                        type="textArea"
+                        key={this.state.selectedId + "extraNotes"}
+                    />
                     {/* <PokemonNotes /> */}
                 </CurrentPokemonLayoutItem>
                 <CurrentPokemonLayoutItem fullWidth>

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -253,8 +253,18 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                         {pokemon.notes && (
                             <div
                                 className="pokemon-notes"
+                                style={{ whiteSpace: "pre-wrap" }}
                                 dangerouslySetInnerHTML={{
                                     __html: pokemon.notes,
+                                }}
+                            />
+                        )}
+                        {pokemon.extraNotes && (
+                            <div
+                                className="pokemon-notes pokemon-extra-notes"
+                                style={{ whiteSpace: "pre-wrap" }}
+                                dangerouslySetInnerHTML={{
+                                    __html: pokemon.extraNotes,
                                 }}
                             />
                         )}

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon2.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon2.tsx
@@ -190,6 +190,7 @@ export function TeamPokemon({
             <GenderElementReact gender={pokemon?.gender} />,
         ),
         notes: pokemon.notes ?? "",
+        extraNotes: pokemon.extraNotes ?? "",
         linkedPokemon: ReactDOMServer.renderToString(
             <LinkedPokemon style={style} linkedPokemon={linkedPokemon} />,
         ),
@@ -233,6 +234,7 @@ export function TeamPokemon({
         .replace(/\{{icon}}/g, view.icon)
         .replace(/\{{linkedPokemon}}/g, view.linkedPokemon)
         .replace(/\{{notes}}/g, view.notes)
+        .replace(/\{{extraNotes}}/g, view.extraNotes)
         .replace(/\{{itemComponent}}/g, view.itemComponent)
         .replace(/\{{pokeballComponent}}/g, view.pokeballComponent)
         .replace(/\{{movesColoredWithClasses}}/g, view.movesColoredWithClasses)

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
@@ -219,6 +219,30 @@ describe("TeamPokemonInfo", () => {
         expect(screen.queryByTestId("moves")).toBeNull();
     });
 
+    it("renders primary and extra notes as separate multiline blocks", () => {
+        const { container } = render(
+            <TeamPokemonInfo
+                generation={Generation.Gen3}
+                style={baseStyle}
+                pokemon={{
+                    ...basePokemon,
+                    notes: "EVs: 252 HP\n252 Defense",
+                    extraNotes: "Keep for Rival",
+                }}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        const noteBlocks = container.querySelectorAll(".pokemon-notes");
+        expect(noteBlocks).toHaveLength(2);
+        expect(noteBlocks[0].textContent).toBe("EVs: 252 HP\n252 Defense");
+        expect((noteBlocks[0] as HTMLElement).style.whiteSpace).toBe("pre-wrap");
+        expect(noteBlocks[1].textContent).toBe("Keep for Rival");
+        expect(noteBlocks[1].className).toContain("pokemon-extra-notes");
+    });
+
     it("shows Gen 1 special stat label", () => {
         const pokemonWithStats: Pokemon = {
             ...basePokemon,

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -35,6 +35,7 @@ export interface Pokemon {
     extraData?: object;
     pokeball?: string;
     notes?: string;
+    extraNotes?: string;
     linkedTo?: Pokemon["id"] | null;
     checkpoints?: Checkpoints;
     gift?: boolean;
@@ -78,6 +79,7 @@ export const PokemonKeys: Pokemon = {
     extraData: {},
     pokeball: "None",
     notes: "",
+    extraNotes: "",
     checkpoints: [],
     gift: false,
     linkedTo: null,

--- a/src/utils/search/__tests__/search.test.ts
+++ b/src/utils/search/__tests__/search.test.ts
@@ -228,6 +228,15 @@ describe("compileQuery", () => {
             expect(match('move:"ice beam"', testTeam[6])).toBe(true);
             expect(match("move:shadow", testTeam[6])).toBe(true); // has "Shadow Ball"
         });
+
+        it("matches extra notes field", () => {
+            const pokemon = createPokemon({
+                extraNotes: "EV spread: 252 HP / 252 Defense",
+            });
+
+            expect(match("extranotes:defense", pokemon)).toBe(true);
+            expect(match("extranotes:speed", pokemon)).toBe(false);
+        });
     });
 
     describe("numeric filters", () => {

--- a/src/utils/search/normalize.ts
+++ b/src/utils/search/normalize.ts
@@ -49,6 +49,7 @@ export function normalizePokemon(pokemon: Pokemon): NormalizedPokemon {
         mvp: Boolean(pokemon.mvp),
         gift: Boolean(pokemon.gift),
         notes: normalizeString(pokemon.notes),
+        extraNotes: normalizeString(pokemon.extraNotes),
     };
 }
 
@@ -98,5 +99,4 @@ export function clearNormalizationCache(): void {
     // WeakMap doesn't have a clear method, so we just create a new one
     // This function exists for API consistency but the WeakMap handles cleanup automatically
 }
-
 

--- a/src/utils/search/types.ts
+++ b/src/utils/search/types.ts
@@ -135,6 +135,7 @@ export interface NormalizedPokemon {
     mvp: boolean;
     gift: boolean;
     notes: string; // lowercase
+    extraNotes: string; // lowercase
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -183,6 +184,7 @@ export const FIELD_ALIASES: Record<string, keyof NormalizedPokemon> = {
     mvp: "mvp",
     gift: "gift",
     notes: "notes",
+    extranotes: "extraNotes",
     name: "nickname",
 };
 
@@ -207,5 +209,4 @@ export const BOOLEAN_FIELDS = new Set<string>([
 
 /** Fields that are numeric */
 export const NUMERIC_FIELDS = new Set<string>(["level", "metLevel"]);
-
 


### PR DESCRIPTION
## Summary
- add a second Pokemon notes field for separating stats/EVs from general notes
- preserve line breaks in rendered Pokemon notes with pre-wrap
- include extra notes in search normalization and import empty-slot detection

Fixes #1158

## Verification
- npm run lint
- npm run test:run
- npm run typecheck
- npm run build
- git diff --check
- Playwright smoke: seeded a Pokemon with multiline notes and extraNotes, expanded the editor, verified Extra Notes textarea value, and verified result renders two pre-wrap .pokemon-notes blocks