### PR TITLE
Add move suggestions to Pokemon editor

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
@@ -7,6 +7,7 @@ import {
     formatBallText,
     typeToColor,
     getContrastColor,
+    movesByType,
     matchNatureToToxtricityForme,
     Species,
     normalizePokeballName,
@@ -413,12 +414,27 @@ export function PokemonMoveInput({
         () => (v: string) => customMoveMap?.find((m) => m?.move === v)?.type,
         [customMoveMap],
     );
+    const moveSuggestionListId = `move-suggestions-${selectedId || "pokemon"}`;
+    const moveSuggestions = useMemo(() => {
+        const standardMoves = Object.values(movesByType).flat();
+        const customMoves =
+            customMoveMap
+                ?.map((move) => move?.move)
+                .filter((move): move is string => Boolean(move)) ?? [];
+
+        return Array.from(new Set([...standardMoves, ...customMoves])).sort(
+            (a, b) => a.localeCompare(b),
+        );
+    }, [customMoveMap]);
 
     return (
         <ErrorBoundary>
             <TagInput
                 fill
                 leftIcon="ninja"
+                inputProps={{
+                    list: moveSuggestionListId,
+                }}
                 tagProps={(v, _i) => {
                     // @TODO: Fix inconsitencies with bad parameter types
                     const background =
@@ -445,7 +461,13 @@ export function PokemonMoveInput({
                     }
                 }}
                 values={Array.isArray(value) ? value.map(String) : []}
-            />
+            >
+                <datalist id={moveSuggestionListId}>
+                    {moveSuggestions.map((move) => (
+                        <option key={move} value={move} />
+                    ))}
+                </datalist>
+            </TagInput>
         </ErrorBoundary>
     );
 }

--- a/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonInput.test.tsx
+++ b/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonInput.test.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { render } from "utils/testUtils";
+import { PokemonMoveInput } from "../CurrentPokemonInput";
+
+describe("<PokemonMoveInput />", () => {
+    it("attaches standard and custom move suggestions to the move input", () => {
+        const { container } = render(
+            <PokemonMoveInput
+                labelName="Moves"
+                inputName="moves"
+                type="moves"
+                value={["Tackle"]}
+                selectedId="test-pokemon"
+                customTypes={[]}
+                customMoveMap={[
+                    { id: "custom-1", move: "Volt Crash", type: "Electric" },
+                ]}
+                setEdit={() => undefined}
+                edit={{ moves: ["Tackle"] }}
+                onChange={() => undefined}
+                key="moves"
+            />,
+        );
+
+        const input = container.querySelector("input");
+        const dataList = container.querySelector("datalist");
+        const options = Array.from(
+            container.querySelectorAll("datalist option"),
+        ).map((option) => option.getAttribute("value"));
+
+        expect(input?.getAttribute("list")).toBe("move-suggestions-test-pokemon");
+        expect(dataList?.id).toBe("move-suggestions-test-pokemon");
+        expect(options).toContain("Tackle");
+        expect(options).toContain("Volt Crash");
+    });
+});


### PR DESCRIPTION
## Summary
- attach a native move suggestion list to the existing move TagInput
- source suggestions from canonical moves plus custom move mappings
- preserve free-form move entry and existing tag/color behavior

Fixes #1140

## Verification
- npm run test:run -- src/components/Editors/PokemonEditor/__tests__/CurrentPokemonInput.test.tsx
- npm run typecheck
- npm run lint -- src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx src/components/Editors/PokemonEditor/__tests__/CurrentPokemonInput.test.tsx
- npm run lint
- npm run test:run
- npm run build
- git diff --check
- Playwright smoke on http://127.0.0.1:18086/: seeded a selected Pokemon and custom move, then verified the move input has a datalist containing canonical Tackle and custom Volt Crash suggestions