### PR TITLE
Add type-based Pokemon backgrounds

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -792,6 +792,24 @@ export class StyleEditorBase extends React.Component<
                 </div>
 
                 <div className={styleEdit}>
+                    <label
+                        htmlFor="pokemonBackgroundSource"
+                        className={cx(Classes.LABEL, Classes.INLINE)}
+                    >
+                        Pokémon Backgrounds
+                    </label>
+                    <HTMLSelect
+                        name="pokemonBackgroundSource"
+                        onChange={(e) => editEvent(e, props)}
+                        value={props.style.pokemonBackgroundSource ?? "accent"}
+                    >
+                        <option value="accent">Accent Color</option>
+                        <option value="game-origin">Game Origin</option>
+                        <option value="type">Pokémon Types</option>
+                    </HTMLSelect>
+                </div>
+
+                <div className={styleEdit}>
                     <Checkbox
                         checked={props.style.displayGameOriginForBoxedAndDead}
                         name="displayGameOriginForBoxedAndDead"

--- a/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
+++ b/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
@@ -4,13 +4,19 @@ import { css, cx } from "emotion";
 
 import { Pokemon } from "models";
 import { selectPokemon } from "actions";
-import { getContrastColor, Styles, gameOfOriginToColor } from "utils";
+import {
+    getContrastColor,
+    getPokemonBackgroundStyle,
+    Styles,
+    gameOfOriginToColor,
+} from "utils";
 import { PokemonIcon } from "components/Pokemon/PokemonIcon/PokemonIcon";
 import { GenderElement } from "components/Common/Shared";
 import { State } from "state";
 
 export type BoxedPokemonProps = Pokemon & { selectPokemon: selectPokemon } & {
     style: Styles;
+    customTypes?: State["customTypes"];
 };
 
 const getAccentColor = (prop: BoxedPokemonProps) =>
@@ -23,24 +29,17 @@ const determineWidth = (isMinimal, numerator): string => {
 // @TODO: fix this messy prop soup
 export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
     const isMinimal = poke?.style?.minimalBoxedLayout;
-    const useGameOfOriginColor =
-        poke?.gameOfOrigin &&
-        poke?.style?.displayGameOriginForBoxedAndDead &&
-        poke?.style?.displayBackgroundInsteadOfBadge;
+    const backgroundStyle = getPokemonBackgroundStyle({
+        customTypes: poke.customTypes,
+        pokemon: poke,
+        style: poke.style,
+    });
     return (
         <div
             className={cx("boxed-pokemon-container")}
             style={{
-                background:
-                    useGameOfOriginColor && poke?.gameOfOrigin
-                        ? gameOfOriginToColor(poke.gameOfOrigin)
-                        : getAccentColor(poke),
-                color:
-                    useGameOfOriginColor && poke?.gameOfOrigin
-                        ? getContrastColor(
-                              gameOfOriginToColor(poke.gameOfOrigin),
-                          )
-                        : getContrastColor(getAccentColor(poke)),
+                background: backgroundStyle.background,
+                color: backgroundStyle.color,
                 width: determineWidth(
                     isMinimal,
                     poke?.style.boxedPokemonPerLine,
@@ -68,10 +67,8 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
                     className="boxed-pokemon-info"
                     style={{
                         borderLeftColor:
-                            useGameOfOriginColor && poke?.gameOfOrigin
-                                ? getContrastColor(
-                                      gameOfOriginToColor(poke.gameOfOrigin),
-                                  )
+                            backgroundStyle.source !== "accent"
+                                ? backgroundStyle.color
                                 : getAccentColor(poke),
                     }}
                 >
@@ -82,7 +79,7 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
                         {poke?.nickname} {GenderElement(poke?.gender)}{" "}
                         {poke?.level ? <span>lv. {poke?.level}</span> : null}
                         {poke?.style?.displayGameOriginForBoxedAndDead &&
-                            !poke?.style?.displayBackgroundInsteadOfBadge &&
+                            !backgroundStyle.usesGameOriginBackground &&
                             poke?.gameOfOrigin && (
                                 <span
                                     className="boxed-pokemon-gameoforigin"
@@ -112,7 +109,10 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
 };
 
 export const BoxedPokemon = connect(
-    (state: Pick<State, keyof State>) => ({ style: state.style }),
+    (state: Pick<State, keyof State>) => ({
+        customTypes: state.customTypes,
+        style: state.style,
+    }),
     {
         selectPokemon,
     },

--- a/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
+++ b/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { vi } from "vitest";
 import { BoxedPokemonBase, BoxedPokemonProps } from "../BoxedPokemon";
 import { render, screen, waitFor } from "utils/testUtils";
 import { PokemonFixtures } from "utils/fixtures";
@@ -17,5 +18,20 @@ describe(BoxedPokemonBase.name, () => {
         expect(screen.getByTestId("boxed-pokemon-name").textContent).toContain(
             PokemonFixtures.Pikachu.nickname,
         );
+    });
+
+    it("uses type-colored backgrounds when selected", () => {
+        const props: BoxedPokemonProps = {
+            ...PokemonFixtures.Pikachu,
+            selectPokemon: vi.fn(),
+            style: { ...styleDefaults, pokemonBackgroundSource: "type" },
+        };
+
+        const { container } = render(<BoxedPokemonBase {...props} />);
+
+        const boxedPokemon = container.querySelector(
+            ".boxed-pokemon-container",
+        ) as HTMLElement;
+        expect(boxedPokemon.style.backgroundImage).toContain("#E3E039");
     });
 });

--- a/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
+++ b/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
@@ -18,6 +18,7 @@ import {
     feature,
     Forme,
     gameOfOriginToColor,
+    getPokemonBackgroundStyle,
     TemplateName,
 } from "utils";
 import { selectPokemon } from "actions";
@@ -56,6 +57,7 @@ export type DeadPokemonProps = {
     style: Styles;
     game: Game;
     minimal: boolean;
+    customTypes?: State["customTypes"];
 } & Pokemon;
 
 // TODO: Convert to Class
@@ -74,8 +76,6 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
             return species;
         }
     };
-    const getAccentColor = (prop: DeadPokemonProps) =>
-        prop.style ? prop.style.accentColor : "#111111";
     const renderPlainIcon = () => (
         <PokemonIconPlain
             onClick={() => poke.selectPokemon(poke.id)}
@@ -98,10 +98,11 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
             editorDarkMode={poke.style.editorDarkMode}
         />
     );
-    const useGameOfOriginColor =
-        poke.gameOfOrigin &&
-        poke.style.displayGameOriginForBoxedAndDead &&
-        poke.style.displayBackgroundInsteadOfBadge;
+    const backgroundStyle = getPokemonBackgroundStyle({
+        customTypes: poke.customTypes,
+        pokemon: poke,
+        style: poke.style,
+    });
     const EMMA_MODE = feature.emmaMode;
 
     if (isMinimal && isCompactWithIcons) {
@@ -111,14 +112,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                 data-league={poke.champion}
                 data-game={poke.gameOfOrigin}
                 style={{
-                    background: useGameOfOriginColor
-                        ? gameOfOriginToColor(poke.gameOfOrigin!)
-                        : getAccentColor(poke),
-                    color: useGameOfOriginColor
-                        ? getContrastColor(
-                              gameOfOriginToColor(poke.gameOfOrigin!),
-                          )
-                        : getContrastColor(getAccentColor(poke)),
+                    background: backgroundStyle.background,
+                    color: backgroundStyle.color,
                     height: "50px",
                     fontSize: "90%",
                     //margin: '1px',
@@ -173,7 +168,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                             {poke.causeOfDeath}
                         </div>
                         {style.displayGameOriginForBoxedAndDead &&
-                            !poke.style.displayBackgroundInsteadOfBadge &&
+                            !backgroundStyle.usesGameOriginBackground &&
                             poke.gameOfOrigin && (
                                 <span
                                     className="pokemon-gameoforigin"
@@ -210,14 +205,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                 className={"dead-pokemon-container"}
                 data-league={poke.champion}
                 style={{
-                    background: useGameOfOriginColor
-                        ? gameOfOriginToColor(poke.gameOfOrigin!)
-                        : getAccentColor(poke),
-                    color: useGameOfOriginColor
-                        ? getContrastColor(
-                              gameOfOriginToColor(poke.gameOfOrigin!),
-                          )
-                        : getContrastColor(getAccentColor(poke)),
+                    background: backgroundStyle.background,
+                    color: backgroundStyle.color,
                     height: "50px",
                     fontSize: "90%",
                 }}
@@ -243,7 +232,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                     </div>
                     <div data-testid="cause-of-death">{poke.causeOfDeath}</div>
                     {style.displayGameOriginForBoxedAndDead &&
-                        !poke.style.displayBackgroundInsteadOfBadge &&
+                        !backgroundStyle.usesGameOriginBackground &&
                         poke.gameOfOrigin && (
                             <span
                                 className="pokemon-gameoforigin"
@@ -276,12 +265,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
             className={"dead-pokemon-container"}
             data-league={poke.champion}
             style={{
-                background: useGameOfOriginColor
-                    ? gameOfOriginToColor(poke.gameOfOrigin!)
-                    : getAccentColor(poke),
-                color: useGameOfOriginColor
-                    ? getContrastColor(gameOfOriginToColor(poke.gameOfOrigin!))
-                    : getContrastColor(getAccentColor(poke)),
+                background: backgroundStyle.background,
+                color: backgroundStyle.color,
             }}
         >
             {style.template !== "Generations" ? (
@@ -329,7 +314,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                     {poke.causeOfDeath}
                 </div>
                 {style.displayGameOriginForBoxedAndDead &&
-                    !poke.style.displayBackgroundInsteadOfBadge &&
+                    !backgroundStyle.usesGameOriginBackground &&
                     poke.gameOfOrigin && (
                         <span
                             className="pokemon-gameoforigin"
@@ -358,6 +343,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
 
 export const DeadPokemon = connect(
     (state: Pick<State, keyof State>) => ({
+        customTypes: state.customTypes,
         style: state.style,
         game: state.game,
     }),

--- a/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
+++ b/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import { DeadPokemonBase } from "../DeadPokemon";
-import { generateEmptyPokemon, styleDefaults } from "utils";
+import { generateEmptyPokemon, styleDefaults, Types } from "utils";
 import { render, screen } from "utils/testUtils";
 
 const poke = {
     ...generateEmptyPokemon(),
     species: "Pikachu",
     nickname: "Pikazzy",
+    types: [Types.Electric, Types.Electric] as [Types, Types],
     level: 50,
     metLevel: 3,
     causeOfDeath: "Died doing what he loved.",
@@ -26,5 +27,22 @@ describe("<DeadPokemon />", () => {
         expect(screen.getByTestId("cause-of-death").textContent).toContain(
             poke.causeOfDeath,
         );
+    });
+
+    it("uses type-colored backgrounds when selected", () => {
+        const { container } = render(
+            <DeadPokemonBase
+                game={{ name: "Red", customName: "" }}
+                style={{ ...styleDefaults, pokemonBackgroundSource: "type" }}
+                selectPokemon={vi.fn()}
+                minimal={false}
+                {...poke}
+            />,
+        );
+
+        const deadPokemon = container.querySelector(
+            ".dead-pokemon-container",
+        ) as HTMLElement;
+        expect(deadPokemon.style.backgroundImage).toContain("#E3E039");
     });
 });

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -11,6 +11,7 @@ import {
     getGameGeneration,
     getContrastColor,
     gameOfOriginToColor,
+    getPokemonBackgroundStyle,
     TemplateName,
     Types,
     Forme,
@@ -46,9 +47,14 @@ const GameOfOriginBadge = ({
     pokemon: Pokemon;
     style: Styles;
 }) => {
+    const usesGameOriginBackground = getPokemonBackgroundStyle({
+        pokemon,
+        style,
+    }).usesGameOriginBackground;
+
     if (
         !style.displayGameOriginForBoxedAndDead ||
-        style.displayBackgroundInsteadOfBadge ||
+        usesGameOriginBackground ||
         !pokemon.gameOfOrigin ||
         pokemon.gameOfOrigin === "None"
     ) {
@@ -119,11 +125,13 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
         const gameOfOriginColor = pokemon.gameOfOrigin
             ? gameOfOriginToColor(pokemon.gameOfOrigin)
             : "";
-        const useGameOfOriginBackground = Boolean(
-            style.displayGameOriginForBoxedAndDead &&
-                style.displayBackgroundInsteadOfBadge &&
-                gameOfOriginColor,
-        );
+        const pokemonBackground = getPokemonBackgroundStyle({
+            customTypes,
+            pokemon,
+            style,
+        });
+        const useGameOfOriginBackground =
+            pokemonBackground.usesGameOriginBackground && Boolean(gameOfOriginColor);
         const isCompactTheme =
             style.template === TemplateName.Compact ||
             style.template === TemplateName.CompactWithIcons;
@@ -160,11 +168,11 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                     style={{
                         backgroundColor: isCardsTheme
                             ? undefined
-                            : useGameOfOriginBackground
-                              ? gameOfOriginColor
-                              : accentColor,
+                            : pokemonBackground.source === "type"
+                              ? undefined
+                              : pokemonBackground.background,
                         // backgroundImage: isCardsTheme ? undefined : `linear-gradient(to right, #2d2d2d 1px, transparent 1px), linear-gradient(to bottom, #2d2d2d 1px, transparent 1px)`,
-                        backgroundImage: isCompactTheme
+                        backgroundImage: isCompactTheme || pokemonBackground.source === "type"
                             ? getBackgroundGradient(
                                   pokemon.types != null && !pokemon.egg
                                       ? pokemon?.types[1]
@@ -179,9 +187,7 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                             ? getContrastColor(
                                   typeToColor(getTypeOrNone(), customTypes),
                               )
-                            : useGameOfOriginBackground
-                              ? getContrastColor(gameOfOriginColor)
-                            : getContrastColor(accentColor),
+                            : pokemonBackground.color,
                     }}
                 >
                     <div className="pokemon-info-inner">

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
@@ -219,6 +219,25 @@ describe("TeamPokemonInfo", () => {
         expect(screen.queryByTestId("moves")).toBeNull();
     });
 
+    it("uses type-colored backgrounds when selected", () => {
+        const { container } = render(
+            <TeamPokemonInfo
+                generation={Generation.Gen3}
+                style={{ ...baseStyle, pokemonBackgroundSource: "type" }}
+                pokemon={basePokemon}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        const pokemonInfo = container.querySelector(
+            ".pokemon-info",
+        ) as HTMLElement;
+        expect(pokemonInfo.style.backgroundImage).toContain("#39BF3C");
+        expect(pokemonInfo.style.backgroundImage).toContain("#75226B");
+    });
+
     it("shows Gen 1 special stat label", () => {
         const pokemonWithStats: Pokemon = {
             ...basePokemon,

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -82,7 +82,7 @@ describe("styleDefaults", () => {
         expect(objectPropertiesWhere(styleDefaults, (p) => p === "round")).toBe(
             1,
         );
-        expect(objectPropertiesWhere(styleDefaults, (p) => Boolean(p))).toBe(28);
+        expect(objectPropertiesWhere(styleDefaults, (p) => Boolean(p))).toBe(29);
     });
 });
 

--- a/src/utils/getters/__tests__/getPokemonBackgroundStyle.test.ts
+++ b/src/utils/getters/__tests__/getPokemonBackgroundStyle.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+    getBackgroundGradient,
+    getPokemonBackgroundStyle,
+    styleDefaults,
+    Types,
+} from "utils";
+
+describe("getBackgroundGradient", () => {
+    it("returns valid gradient syntax for single and dual types", () => {
+        expect(getBackgroundGradient(Types.Grass, Types.Poison, [])).toBe(
+            "linear-gradient(to right, #39BF3C, #75226B)",
+        );
+        expect(getBackgroundGradient(Types.Fire, undefined as never, [])).toBe(
+            "linear-gradient(to right, #EB3434, #EB3434)",
+        );
+    });
+});
+
+describe("getPokemonBackgroundStyle", () => {
+    it("defaults to the accent background", () => {
+        expect(
+            getPokemonBackgroundStyle({
+                pokemon: { types: [Types.Grass, Types.Poison] },
+                style: { ...styleDefaults, accentColor: "#123456" },
+            }),
+        ).toMatchObject({
+            background: "#123456",
+            source: "accent",
+            usesGameOriginBackground: false,
+        });
+    });
+
+    it("uses type gradients when selected", () => {
+        expect(
+            getPokemonBackgroundStyle({
+                pokemon: { types: [Types.Grass, Types.Poison] },
+                style: { ...styleDefaults, pokemonBackgroundSource: "type" },
+            }),
+        ).toMatchObject({
+            background: "linear-gradient(to right, #39BF3C, #75226B)",
+            source: "type",
+            usesGameOriginBackground: false,
+        });
+    });
+
+    it("preserves legacy game-origin background settings", () => {
+        expect(
+            getPokemonBackgroundStyle({
+                pokemon: {
+                    gameOfOrigin: "FireRed",
+                    types: [Types.Fire, Types.Fire],
+                },
+                style: {
+                    ...styleDefaults,
+                    displayGameOriginForBoxedAndDead: true,
+                    displayBackgroundInsteadOfBadge: true,
+                    pokemonBackgroundSource: undefined as never,
+                },
+            }),
+        ).toMatchObject({
+            background: "#ef4e21",
+            source: "game-origin",
+            usesGameOriginBackground: true,
+        });
+    });
+});

--- a/src/utils/getters/getBackgroundGradient.ts
+++ b/src/utils/getters/getBackgroundGradient.ts
@@ -13,12 +13,12 @@ export const getBackgroundGradient = (
             return `linear-gradient(to right, ${typeToColor(typeA, customTypes)}, ${typeToColor(
                 typeA,
                 customTypes,
-            )}`;
+            )})`;
         }
     } else {
         return `linear-gradient(to right, ${typeToColor(typeA, customTypes)}, ${typeToColor(
             typeB,
             customTypes,
-        )}`;
+        )})`;
     }
 };

--- a/src/utils/getters/getPokemonBackgroundStyle.ts
+++ b/src/utils/getters/getPokemonBackgroundStyle.ts
@@ -1,0 +1,78 @@
+import { Pokemon } from "models";
+import { State } from "state";
+import { Game } from "../data/listOfGames";
+import { gameOfOriginToColor } from "../formatters/gameOfOriginToColor";
+import { PokemonBackgroundSource, Styles } from "../styleDefaults";
+import { Types } from "../Types";
+import { typeToColor } from "../typeToColor";
+import { getBackgroundGradient } from "./getBackgroundGradient";
+import { getContrastColor } from "./getContrastColor";
+
+export interface PokemonBackgroundStyle {
+    background: string;
+    color: string;
+    source: PokemonBackgroundSource;
+    usesGameOriginBackground: boolean;
+}
+
+const getBackgroundSource = (style: Styles): PokemonBackgroundSource => {
+    if (style.pokemonBackgroundSource) {
+        return style.pokemonBackgroundSource;
+    }
+
+    return style.displayGameOriginForBoxedAndDead &&
+        style.displayBackgroundInsteadOfBadge
+        ? "game-origin"
+        : "accent";
+};
+
+const getAccentColor = (style: Styles | undefined, fallback: string) =>
+    style?.accentColor || fallback;
+
+export const getPokemonBackgroundStyle = ({
+    accentFallback = "#111111",
+    customTypes,
+    pokemon,
+    style,
+}: {
+    accentFallback?: string;
+    customTypes?: State["customTypes"];
+    pokemon: Pick<Pokemon, "gameOfOrigin" | "types">;
+    style: Styles;
+}): PokemonBackgroundStyle => {
+    const source = getBackgroundSource(style);
+    const accentColor = getAccentColor(style, accentFallback);
+
+    if (source === "type" && pokemon.types?.[0]) {
+        const primaryType = pokemon.types[0] as keyof typeof Types;
+        const secondaryType = (pokemon.types[1] ?? pokemon.types[0]) as keyof typeof Types;
+        const primaryTypeColor = typeToColor(primaryType, customTypes) || accentColor;
+
+        return {
+            background: getBackgroundGradient(primaryType, secondaryType, customTypes ?? []),
+            color: getContrastColor(primaryTypeColor),
+            source,
+            usesGameOriginBackground: false,
+        };
+    }
+
+    if (source === "game-origin" && pokemon.gameOfOrigin) {
+        const gameOriginColor = gameOfOriginToColor(pokemon.gameOfOrigin as Game);
+
+        if (gameOriginColor) {
+            return {
+                background: gameOriginColor,
+                color: getContrastColor(gameOriginColor),
+                source,
+                usesGameOriginBackground: true,
+            };
+        }
+    }
+
+    return {
+        background: accentColor,
+        color: getContrastColor(accentColor),
+        source: "accent",
+        usesGameOriginBackground: false,
+    };
+};

--- a/src/utils/getters/index.ts
+++ b/src/utils/getters/index.ts
@@ -13,4 +13,5 @@ export * from "./getIconFormeSuffix";
 export * from "./getMoveType";
 export * from "./getPatchlessVersion";
 export * from "./getPokemonImage";
+export * from "./getPokemonBackgroundStyle";
 export * from "./getSpriteIcon";

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -9,6 +9,7 @@ export type TeamImagesType =
 export type IconRenderingType = "pixelated" | "auto";
 export type RulesLocation = "inside trainer section" | "bottom" | "top";
 export type ItemStyle = "outer glow" | "round" | "square" | "text";
+export type PokemonBackgroundSource = "accent" | "game-origin" | "type";
 
 export interface StatsOptions {
     averageLevel: boolean;
@@ -58,6 +59,7 @@ export interface Styles {
     boxedPokemonPerLine: number;
     displayGameOriginForBoxedAndDead: boolean;
     displayBackgroundInsteadOfBadge: boolean;
+    pokemonBackgroundSource: PokemonBackgroundSource;
     displayExtraData: boolean;
     useAutoHeight: boolean;
     displayItemAsText: boolean;
@@ -106,6 +108,7 @@ export const styleDefaults: Styles = {
     boxedPokemonPerLine: 6,
     displayGameOriginForBoxedAndDead: false,
     displayBackgroundInsteadOfBadge: false,
+    pokemonBackgroundSource: "accent",
     displayExtraData: true,
     useAutoHeight: true,
     usePokemonGBAFont: false,


### PR DESCRIPTION
Fixes #1151.

## Summary
- adds a `Pokémon Backgrounds` style selector with Accent Color, Game Origin, and Pokémon Types modes
- applies type-color gradient backgrounds to team, boxed, and dead Pokémon cards
- preserves the legacy game-origin background behavior for persisted saves without the new field

## Verification
- `npm run test:run -- src/utils/getters/__tests__/getPokemonBackgroundStyle.test.ts src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx`
- `npm run typecheck`
- targeted `npx eslint` on changed source and test files
- `npm run lint`
- `npm run build`
- `npm run test:run`
- Browser smoke on `http://127.0.0.1:18087/`: seeded Team Bulbasaur, Boxed Charizard, and Dead Pikachu; changed `select[name="pokemonBackgroundSource"]` to `type`; verified Grass/Poison, Fire/Flying, and Electric gradients plus hidden game-origin badges
