### PR TITLE
Disable native dragging for Pokemon icons

### DIFF
--- a/src/components/Pokemon/PokemonIcon/PokemonIcon.tsx
+++ b/src/components/Pokemon/PokemonIcon/PokemonIcon.tsx
@@ -192,6 +192,7 @@ export function PokemonIconPlain({
                             src={image}
                             width={64}
                             height={64}
+                            draggable={false}
                             style={imageStyle}
                             alt={species}
                         />
@@ -199,7 +200,14 @@ export function PokemonIconPlain({
                 </PokemonImage>
             ) : (
                 <img
-                    style={{...imageStyle, filter: isUnknown && editorDarkMode ? "invert(100%) drop-shadow(0 0 1px rgba(0, 0, 0, 1))" : undefined}}
+                    draggable={false}
+                    style={{
+                        ...imageStyle,
+                        filter:
+                            isUnknown && editorDarkMode
+                                ? "invert(100%) drop-shadow(0 0 1px rgba(0, 0, 0, 1))"
+                                : undefined,
+                    }}
                     alt={species}
                     onError={({ currentTarget }) => {
                         currentTarget.onerror = null; // prevents looping

--- a/src/components/Pokemon/PokemonIcon/__tests__/PokemonIcon.test.tsx
+++ b/src/components/Pokemon/PokemonIcon/__tests__/PokemonIcon.test.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { render, screen, waitFor } from "utils/testUtils";
+import { PokemonIconPlain } from "../PokemonIcon";
+
+const baseProps = {
+    id: "pikachu",
+    species: "Pikachu",
+    onClick: vi.fn(),
+    selectedId: null,
+};
+
+describe(PokemonIconPlain.name, () => {
+    it("does not let the default icon image start a native browser drag", () => {
+        render(<PokemonIconPlain {...baseProps} />);
+
+        expect(screen.getByAltText("Pikachu").getAttribute("draggable")).toBe(
+            "false",
+        );
+    });
+
+    it("does not let a custom icon image start a native browser drag", async () => {
+        render(
+            <PokemonIconPlain
+                {...baseProps}
+                customIcon="data:image/png;base64,custom"
+            />,
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByAltText("Pikachu").getAttribute("draggable"),
+            ).toBe("false"),
+        );
+    });
+});


### PR DESCRIPTION
Fixes #1130.
Fixes #1096.

## Summary
- prevents nested default Pokémon icon images from starting native browser image drags
- applies the same native-drag prevention to custom icon images
- keeps the existing React DnD wrapper responsible for moving Pokémon between boxes
- covers the Chrome split/drop-space behavior reported in #1096 by preventing the app image from becoming a native browser drag payload while moving Pokémon

## Verification
- `npm run test:run -- src/components/Pokemon/PokemonIcon/__tests__/PokemonIcon.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/Pokemon/PokemonIcon/PokemonIcon.tsx src/components/Pokemon/PokemonIcon/__tests__/PokemonIcon.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test:run`
- Browser smoke on `http://127.0.0.1:18088/`: seeded Pikachu, verified `#team-pikachu img` renders with `draggable="false"` and DOM `img.draggable === false`
