### PR TITLE
Add editable move slots

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
@@ -15,12 +15,14 @@ import { editPokemon } from "actions";
 
 import { ErrorBoundary } from "components/Common/Shared";
 
-import { TagInput, Classes, TextArea, HTMLSelect } from "@blueprintjs/core";
+import { Classes, TextArea, HTMLSelect } from "@blueprintjs/core";
 import { State } from "state";
 import { Pokemon } from "models";
 import { cx } from "emotion";
 import { useDebounceCallback } from "@react-hook/debounce";
 import { useMemo } from "react";
+
+const MAX_MOVE_SLOTS = 4;
 
 type PokemonInputValue =
     | Pokemon[keyof Pokemon]
@@ -409,46 +411,101 @@ export function PokemonMoveInput({
     selectedId,
 }: PokemonInputProps) {
     const dispatch = useDispatch();
-    const moves = useMemo(
+    const getCustomMoveType = useMemo(
         () => (v: string) => customMoveMap?.find((m) => m?.move === v)?.type,
         [customMoveMap],
     );
+    const values = Array.isArray(value) ? value.map(String) : [];
+    const slotValues = Array.from(
+        { length: MAX_MOVE_SLOTS },
+        (_, index) => values[index] ?? "",
+    );
+    const getMoveColor = (move: string) => {
+        if (!move.trim()) return undefined;
+
+        return (
+            typeToColor(
+                (getCustomMoveType(move) ||
+                    getMoveType(move.trim())) as Parameters<
+                    typeof typeToColor
+                >[0],
+                customTypes,
+            ) || undefined
+        );
+    };
+    const updateMoveSlot =
+        (index: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
+            const moves = setMoveAtSlot(values, index, event.currentTarget.value);
+            if (selectedId) {
+                dispatch(editPokemon({ moves }, selectedId));
+            }
+        };
 
     return (
         <ErrorBoundary>
-            <TagInput
-                fill
-                leftIcon="ninja"
-                tagProps={(v, _i) => {
-                    // @TODO: Fix inconsitencies with bad parameter types
-                    const background =
-                        typeToColor(
-                            // @ts-expect-error @TODO: fix mapping
-                            moves(v) ||
-                                getMoveType(v?.toString()?.trim() || ""),
-                            customTypes,
-                        ) || "transparent";
-                    const color = getContrastColor(background);
-                    return {
-                        style: {
-                            background,
-                            color,
-                        },
-                    };
+            <div
+                style={{
+                    display: "grid",
+                    gap: "0.25rem",
+                    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
                 }}
-                onChange={(values) => {
-                    const edit = {
-                        moves: values,
-                    };
-                    if (selectedId) {
-                        dispatch(editPokemon(edit, selectedId));
-                    }
-                }}
-                values={Array.isArray(value) ? value.map(String) : []}
-            />
+            >
+                {slotValues.map((move, index) => {
+                    const background = getMoveColor(move);
+                    const color = background
+                        ? getContrastColor(background)
+                        : undefined;
+
+                    return (
+                        <label
+                            key={index}
+                            style={{
+                                display: "grid",
+                                gap: "0.125rem",
+                                minWidth: 0,
+                            }}
+                        >
+                            <span className={Classes.TEXT_MUTED}>
+                                Move {index + 1}
+                            </span>
+                            <input
+                                aria-label={`Move ${index + 1}`}
+                                className={Classes.INPUT}
+                                name={`move-${index + 1}`}
+                                onChange={updateMoveSlot(index)}
+                                placeholder={`Move ${index + 1}`}
+                                style={{
+                                    background,
+                                    color,
+                                    minWidth: 0,
+                                }}
+                                value={move}
+                            />
+                        </label>
+                    );
+                })}
+            </div>
         </ErrorBoundary>
     );
 }
+
+export const setMoveAtSlot = (
+    moves: string[],
+    slot: number,
+    value: string,
+) => {
+    const nextMoves = Array.from(
+        { length: MAX_MOVE_SLOTS },
+        (_, index) => moves[index] ?? "",
+    );
+    nextMoves[slot] = value;
+
+    while (nextMoves.length && nextMoves[nextMoves.length - 1].trim() === "") {
+        nextMoves.pop();
+    }
+
+    return nextMoves;
+};
 
 export function CurrentPokemonInput(props: CurrentPokemonInputProps) {
     const { inputName, value, className } = props;

--- a/src/components/Editors/PokemonEditor/__tests__/PokemonMoveInput.test.tsx
+++ b/src/components/Editors/PokemonEditor/__tests__/PokemonMoveInput.test.tsx
@@ -1,0 +1,127 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { editPokemon } from "actions";
+import {
+    PokemonMoveInput,
+    setMoveAtSlot,
+} from "../CurrentPokemonInput";
+import type { PokemonInputProps } from "../CurrentPokemonInput";
+
+const dispatchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("store/reactZustand", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("store/reactZustand")>();
+
+    return {
+        ...actual,
+        useDispatch: () => dispatchMock,
+    };
+});
+
+describe(setMoveAtSlot.name, () => {
+    it("replaces one move without shifting later slots", () => {
+        expect(
+            setMoveAtSlot(
+                ["Tackle", "Quick Attack", "Iron Tail", "Volt Tackle"],
+                0,
+                "Thunderbolt",
+            ),
+        ).toEqual(["Thunderbolt", "Quick Attack", "Iron Tail", "Volt Tackle"]);
+    });
+
+    it("preserves later moves when a middle slot is cleared", () => {
+        expect(
+            setMoveAtSlot(
+                ["Tackle", "Quick Attack", "Iron Tail", "Volt Tackle"],
+                1,
+                "",
+            ),
+        ).toEqual(["Tackle", "", "Iron Tail", "Volt Tackle"]);
+    });
+
+    it("trims empty trailing slots", () => {
+        expect(setMoveAtSlot(["Tackle", "Growl"], 1, "")).toEqual(["Tackle"]);
+    });
+});
+
+describe(PokemonMoveInput.name, () => {
+    beforeEach(() => {
+        dispatchMock.mockClear();
+    });
+
+    const renderMoveInput = (value: string[]) => {
+        const props: PokemonInputProps = {
+            edit: { moves: value },
+            inputName: "moves",
+            key: "moves",
+            labelName: "Moves",
+            onChange: vi.fn(),
+            selectedId: "pokemon-1",
+            setEdit: vi.fn(),
+            type: "moves",
+            value,
+        };
+
+        const { key, ...inputProps } = props;
+
+        return render(<PokemonMoveInput key={key} {...inputProps} />);
+    };
+
+    it("renders four independently editable move slots", () => {
+        renderMoveInput(["Tackle", "Quick Attack"]);
+
+        expect(screen.getByLabelText("Move 1")).toBeTruthy();
+        expect(screen.getByLabelText("Move 2")).toBeTruthy();
+        expect(screen.getByLabelText("Move 3")).toBeTruthy();
+        expect(screen.getByLabelText("Move 4")).toBeTruthy();
+    });
+
+    it("updates the edited slot while keeping later moves in place", () => {
+        renderMoveInput([
+            "Tackle",
+            "Quick Attack",
+            "Iron Tail",
+            "Volt Tackle",
+        ]);
+
+        fireEvent.change(screen.getByLabelText("Move 1"), {
+            target: { value: "Thunderbolt" },
+        });
+
+        expect(dispatchMock).toHaveBeenCalledWith(
+            editPokemon(
+                {
+                    moves: [
+                        "Thunderbolt",
+                        "Quick Attack",
+                        "Iron Tail",
+                        "Volt Tackle",
+                    ],
+                },
+                "pokemon-1",
+            ),
+        );
+    });
+
+    it("can clear an earlier slot without removing later moves", () => {
+        renderMoveInput([
+            "Tackle",
+            "Quick Attack",
+            "Iron Tail",
+            "Volt Tackle",
+        ]);
+
+        fireEvent.change(screen.getByLabelText("Move 2"), {
+            target: { value: "" },
+        });
+
+        expect(dispatchMock).toHaveBeenCalledWith(
+            editPokemon(
+                {
+                    moves: ["Tackle", "", "Iron Tail", "Volt Tackle"],
+                },
+                "pokemon-1",
+            ),
+        );
+    });
+});


### PR DESCRIPTION
Fixes #1127.

## Summary
- replaces the one-piece move tag input with four editable move slots
- lets users replace move 1, 2, 3, or 4 directly without clearing later moves
- preserves later slot positions when an earlier move is cleared, while trimming empty trailing slots

## Verification
- `npm run test:run -- src/components/Editors/PokemonEditor/__tests__/PokemonMoveInput.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx src/components/Editors/PokemonEditor/__tests__/PokemonMoveInput.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test:run`
- Browser smoke on `http://127.0.0.1:18090/`: seeded a Pikachu with four moves; verified all four move slots rendered; changed slot 1 from `Tackle` to `Thunderbolt` and slots 2-4 stayed in place; cleared slot 2 and slots 3-4 stayed in place
