### PR TITLE
Fix custom icon sizing

### DIFF
--- a/src/components/Pokemon/PokemonIcon/PokemonIcon.tsx
+++ b/src/components/Pokemon/PokemonIcon/PokemonIcon.tsx
@@ -57,6 +57,20 @@ type IconURLArgs = Pick<
     "id" | "species" | "forme" | "shiny" | "gender" | "customIcon" | "egg"
 >;
 
+export const getCustomIconImageStyle = (
+    imageStyle?: React.CSSProperties,
+): React.CSSProperties => {
+    const iconSize = imageStyle?.width ?? imageStyle?.height ?? "32px";
+
+    return {
+        ...imageStyle,
+        height: imageStyle?.height ?? iconSize,
+        maxWidth: iconSize,
+        objectFit: "contain",
+        width: iconSize,
+    };
+};
+
 const usePokemonDrag = (props: BasePokemonIconProps) => {
     const [, dragRef] = useDrag({
         type: "POKEMON_ICON",
@@ -188,11 +202,11 @@ export function PokemonIconPlain({
                 <PokemonImage url={customIcon}>
                     {(image) => (
                         <ResizedImage
-                            // Keep layout consistent with default icons, but cap custom icon data at 64x64.
+                            // Resize custom data, then render it inside the same box as default icons.
                             src={image}
                             width={64}
                             height={64}
-                            style={imageStyle}
+                            style={getCustomIconImageStyle(imageStyle)}
                             alt={species}
                         />
                     )}

--- a/src/components/Pokemon/PokemonIcon/__tests__/PokemonIconCustomImages.test.tsx
+++ b/src/components/Pokemon/PokemonIcon/__tests__/PokemonIconCustomImages.test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { render, screen } from "utils/testUtils";
+import {
+    getCustomIconImageStyle,
+    PokemonIconPlain,
+} from "../PokemonIcon";
+
+describe(getCustomIconImageStyle.name, () => {
+    it("sets stable square bounds for custom icon images", () => {
+        expect(
+            getCustomIconImageStyle({
+                height: "32px",
+                imageRendering: "pixelated",
+                maxWidth: "auto",
+            }),
+        ).toEqual({
+            height: "32px",
+            imageRendering: "pixelated",
+            maxWidth: "32px",
+            objectFit: "contain",
+            width: "32px",
+        });
+    });
+});
+
+describe(PokemonIconPlain.name, () => {
+    it("renders custom icons as contained square images", () => {
+        render(
+            <PokemonIconPlain
+                customIcon="data:image/png;base64,custom"
+                imageStyle={{ height: "32px", maxWidth: "auto" }}
+                onClick={vi.fn()}
+                selectedId={null}
+                species="Pikachu"
+            />,
+        );
+
+        const image = screen.getByAltText("Pikachu");
+
+        expect(image.style.height).toBe("32px");
+        expect(image.style.maxWidth).toBe("32px");
+        expect(image.style.objectFit).toBe("contain");
+        expect(image.style.width).toBe("32px");
+    });
+});


### PR DESCRIPTION
Fixes #1121
Fixes #666

## Summary
- Render custom Pokemon icons inside a stable square icon box instead of preserving `maxWidth: auto`.
- Keep custom icons contained with `object-fit: contain` so oversized uploaded assets stay centered and crisp at icon size.
- Add focused coverage for the custom icon style helper and rendered custom icon styles.

## Validation
- `npm run test:run -- src/components/Pokemon/PokemonIcon/__tests__/PokemonIconCustomImages.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/Pokemon/PokemonIcon/PokemonIcon.tsx src/components/Pokemon/PokemonIcon/__tests__/PokemonIconCustomImages.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test:run`
- Browser smoke on `http://127.0.0.1:18091/`: seeded a boxed Pokemon with a large custom icon data URL, injected `img { height: auto !important; }`, and verified the rendered boxed icon stayed 32x32 with `max-width: 32px` and `object-fit: contain`.

Refs #658 (custom icons portion).