### PR TITLE
Constrain custom checkpoint badges

### DIFF
--- a/src/components/Features/Result/Result.css
+++ b/src/components/Features/Result/Result.css
@@ -88,6 +88,11 @@
 .badge-wrapper img {
     height: 1.5rem;
 }
+.badge-wrapper img.custom-checkpoint {
+    flex: 0 0 1.5rem;
+    object-fit: contain;
+    width: 1.5rem;
+}
 .pokemon-shiny {
     background: #eee;
     border-radius: 50%;
@@ -454,6 +459,11 @@
     height: 24px;
     margin: 0 2px 0 0;
 }
+.pokemon-checkpoint.custom-checkpoint {
+    flex: 0 0 24px;
+    object-fit: contain;
+    width: 24px;
+}
 
 .pokemon-checkpoint.not-obtained {
     display: none;
@@ -462,4 +472,3 @@
 .pokemon-checkpoint.obtained {
     display: flex;
 }
-

--- a/src/components/Features/Result/TrainerResult.tsx
+++ b/src/components/Features/Result/TrainerResult.tsx
@@ -58,6 +58,9 @@ export const TrainerColumnItem = ({
 const getClearedCheckpointName = (checkpoint: Badge | string) =>
     typeof checkpoint === "string" ? checkpoint : checkpoint.name;
 
+export const isCustomCheckpointImage = (image: string) =>
+    image.startsWith("http") || image.startsWith("data");
+
 export interface CheckpointsDisplayProps {
     style: State["style"];
     trainer?: State["trainer"];
@@ -106,6 +109,9 @@ export function CheckpointsDisplay({
                             className={cx(
                                 className ?? "",
                                 obtained ? "obtained" : "not-obtained",
+                                isCustomCheckpointImage(badge.image)
+                                    ? "custom-checkpoint"
+                                    : "",
                             )}
                             style={
                                 isSWSH(name) && !trainer?.hasEditedCheckpoints
@@ -119,8 +125,7 @@ export function CheckpointsDisplay({
                             alt={badge.name}
                             data-badge={badge.name}
                             src={
-                                badge.image.startsWith("http") ||
-                                badge.image.startsWith("data")
+                                isCustomCheckpointImage(badge.image)
                                     ? badge.image
                                     : `./img/checkpoints/${badge.image}.png`
                             }

--- a/src/components/Features/Result/__tests__/TrainerResult.test.tsx
+++ b/src/components/Features/Result/__tests__/TrainerResult.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { isCustomCheckpointImage } from "../TrainerResult";
+
+describe(isCustomCheckpointImage.name, () => {
+    it("identifies uploaded and remote checkpoint images", () => {
+        expect(isCustomCheckpointImage("https://example.com/badge.png")).toBe(
+            true,
+        );
+        expect(isCustomCheckpointImage("data:image/png;base64,badge")).toBe(
+            true,
+        );
+        expect(isCustomCheckpointImage("boulder-badge")).toBe(false);
+    });
+});

--- a/src/components/Features/Result/themes.css
+++ b/src/components/Features/Result/themes.css
@@ -716,6 +716,10 @@
 .compact-with-icons .badge-wrapper img {
     height: 2rem !important;
 }
+.compact-with-icons .badge-wrapper img.custom-checkpoint {
+    flex-basis: 2rem;
+    width: 2rem;
+}
 .compact-with-icons
     .dead-pokemon-container
     div:nth-of-type(2)


### PR DESCRIPTION
Fixes #1120

## Summary
- Tag remote/data checkpoint badge images as custom checkpoints.
- Render custom trainer and Pokemon checkpoint badges in fixed square boxes with `object-fit: contain`, preventing wide custom images from forcing an extra row.
- Preserve the Compact with Icons 2rem badge sizing while constraining custom image width/flex-basis.

## Validation
- `npm run test:run -- src/components/Features/Result/__tests__/TrainerResult.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/Features/Result/TrainerResult.tsx src/components/Features/Result/__tests__/TrainerResult.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test:run`
- Browser smoke on `http://127.0.0.1:18092/`: seeded a Compact with Icons run with 12 obtained trainer checkpoints including a wide data-URL custom badge and remote custom badges, then verified the `.badge-wrapper` stayed one row and the wide custom badge rendered as a 32px `object-fit: contain` item.