### PR TITLE
Wrap custom team badge rows

### DIFF
--- a/src/components/Pokemon/TeamPokemon/TeamPokemon2.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon2.tsx
@@ -57,7 +57,10 @@ const LinkedPokemon = ({ linkedPokemon, style }) => {
 const TeamCheckpointsDisplay = ({ game, pokemon, style }) => {
     return (
         <ErrorBoundary>
-            <div className="flex flex-wrap" style={{ maxWidth: "14rem" }}>
+            <div
+                className="flex flex-wrap pokemon-checkpoints"
+                style={{ maxWidth: "14rem" }}
+            >
                 <CheckpointsDisplay
                     className="pokemon-checkpoint"
                     game={game}

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon2.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon2.test.tsx
@@ -34,4 +34,27 @@ describe(TeamPokemon.name, () => {
             "Pikachu",
         );
     });
+
+    it("renders custom HTML checkpoints with the wrapping checkpoint class", () => {
+        const { container } = render(
+            <TeamPokemon
+                {...baseProps}
+                customHTML='<div data-testid="checkpoint-html">{{checkpoints}}</div>'
+                pokemon={{
+                    ...Pikachu,
+                    checkpoints: [
+                        { name: "Boulder Badge", image: "boulder-badge" },
+                    ],
+                }}
+            />,
+        );
+
+        const checkpointWrapper = container.querySelector(
+            ".pokemon-checkpoints",
+        );
+
+        expect(screen.getByTestId("checkpoint-html")).toBeTruthy();
+        expect(checkpointWrapper).toBeTruthy();
+        expect(checkpointWrapper?.className).toContain("flex");
+    });
 });


### PR DESCRIPTION
Fixes #1094

## Summary
- Give the result v2/custom-team checkpoint placeholder the existing `pokemon-checkpoints` wrapper class.
- Reuse the existing checkpoint wrapping CSS so long per-Pokemon badge lists wrap inside the teammate card instead of overflowing horizontally.
- Add coverage for custom HTML rendering `{{checkpoints}}` with the checkpoint wrapper class.

## Validation
- `npm run test:run -- src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon2.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/Pokemon/TeamPokemon/TeamPokemon2.tsx src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon2.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test:run`
- Browser smoke on `http://127.0.0.1:18093/` with `VITE_RESULT_V2=true`: seeded a custom-team-HTML result with one teammate and 12 per-Pokemon checkpoints, verified the checkpoint wrapper has `pokemon-checkpoints`, computes `flex-wrap: wrap`, wraps to two rows, and keeps badges inside the teammate card bounds.