### PR TITLE
Fix Cards boxed outlines and box label contrast

### DIFF
--- a/src/components/Editors/Editor/editor.css
+++ b/src/components/Editors/Editor/editor.css
@@ -256,6 +256,32 @@ input[name="metLevel"] {
     justify-content: center;
     height: 40px;
 }
+.box-label {
+    align-items: center;
+    background: rgba(255, 255, 255, 0.76);
+    border: 1px solid rgba(17, 20, 24, 0.18);
+    border-radius: 0.25rem;
+    box-shadow: 0 1px 2px rgba(17, 20, 24, 0.18);
+    color: #1c2127;
+    display: inline-flex;
+    gap: 0.25rem;
+    margin: 0.25rem;
+    min-height: 2rem;
+    min-width: 5rem;
+    padding: 0.25rem 0.5rem;
+    text-align: center;
+    user-select: none;
+}
+.box-label-can-drop {
+    background: rgba(28, 33, 39, 0.88);
+    border-color: #48aff0;
+    color: #f6f7f9;
+}
+.bp5-dark .box-label {
+    background: rgba(28, 33, 39, 0.82);
+    border-color: rgba(255, 255, 255, 0.22);
+    color: #f6f7f9;
+}
 .box .pokemon-icon img,
 .box .pokemon-icon {
     cursor: pointer;

--- a/src/components/Features/Result/themes.css
+++ b/src/components/Features/Result/themes.css
@@ -120,7 +120,10 @@
 }
 .cards .boxed-pokemon-container {
     background: rgba(0, 0, 0, 0.4);
-    border: unset;
+    border: 1px solid rgba(255, 255, 255, 0.38);
+    box-shadow:
+        inset 0 0 0 1px rgba(0, 0, 0, 0.35),
+        0 1px 3px rgba(0, 0, 0, 0.35);
     width: auto;
 }
 .cards .boxed-pokemon-info {
@@ -159,7 +162,10 @@
 }
 .cards .dead-pokemon-container {
     background: rgba(0, 0, 0, 0.3);
-    border: none;
+    border: 1px solid rgba(255, 255, 255, 0.38);
+    box-shadow:
+        inset 0 0 0 1px rgba(0, 0, 0, 0.35),
+        0 1px 3px rgba(0, 0, 0, 0.35);
     width: 10rem;
     height: 10rem;
     border-radius: 0.25rem;

--- a/src/components/Pokemon/Box/Box.tsx
+++ b/src/components/Pokemon/Box/Box.tsx
@@ -332,22 +332,7 @@ export const Box: React.FC<BoxProps> = (props) => {
                 }
             >
                 <span
-                    style={{
-                        alignItems: "center",
-                        background: canDrop
-                            ? "black"
-                            : "rgba(33, 33, 33, 0.33)",
-                        borderRadius: ".25rem",
-                        color: "#eee",
-                        display: "inline-flex",
-                        minHeight: "2rem",
-                        gap: "0.25rem",
-                        margin: ".25rem",
-                        padding: ".25rem .5rem",
-                        textAlign: "center",
-                        minWidth: "5rem",
-                        userSelect: "none",
-                    }}
+                    className={`box-label${canDrop ? " box-label-can-drop" : ""}`}
                 >
                     <span
                         ref={dragRef}


### PR DESCRIPTION
Fixes #1062

## Summary
- add visible two-tone outlines to Cards-template boxed and dead Pokémon tiles
- move editor box label pill styling out of inline styles and make light-mode labels less inverted against box wallpapers
- keep a darker label treatment for dark mode and drop-target state

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- Browser smoke on the #1062 saved state: boxed/dead Cards tiles now report visible borders/shadows, and editor box labels render as light pills in light mode.