### PR TITLE
Fix champion sprite rendering

### DIFF
--- a/src/components/Pokemon/ChampsPokemon/ChampsPokemon.tsx
+++ b/src/components/Pokemon/ChampsPokemon/ChampsPokemon.tsx
@@ -97,14 +97,16 @@ export class ChampsPokemon extends React.Component<ChampsPokemonProps> {
                 }
             >
                 {(backgroundImage) => (
-                    <img
+                    <span
                         className="champs-pokemon-image"
-                        alt={""}
+                        role="img"
+                        aria-label={`${nickname || species || "Champion Pokémon"} sprite`}
                         style={{
                             backgroundImage,
                             backgroundPosition: "center center",
                             backgroundSize: "contain",
                             backgroundRepeat: "no-repeat",
+                            display: "inline-block",
                             height: "48px",
                             width: "48px",
                         }}

--- a/src/components/Pokemon/ChampsPokemon/__tests__/ChampsPokemon.test.tsx
+++ b/src/components/Pokemon/ChampsPokemon/__tests__/ChampsPokemon.test.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "utils/testUtils";
+
+import { ChampsPokemon } from "../ChampsPokemon";
+
+vi.mock("components/Common/Shared/PokemonImage", () => ({
+    PokemonImage: ({
+        children,
+    }: {
+        children: (image: string) => JSX.Element;
+    }) => <>{children("url(sprite.png)")}</>,
+}));
+
+describe(ChampsPokemon.name, () => {
+    it("renders sprite-mode champion images without an empty img element", () => {
+        const { container } = render(
+            <ChampsPokemon
+                id="champ-charizard"
+                species="Charizard"
+                nickname="Flint"
+                gameOfOrigin="Yellow"
+                useSprites
+            />,
+        );
+
+        const sprite = screen.getByRole("img", { name: "Flint sprite" });
+        expect(sprite.tagName).toBe("SPAN");
+        expect((sprite as HTMLElement).style.backgroundImage).toBe(
+            "url(\"sprite.png\")",
+        );
+        expect(container.querySelector("img.champs-pokemon-image")).toBeNull();
+    });
+});

--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -193,6 +193,26 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             expect(result).toBe(`cors(${expectedUrl})`);
         });
 
+        it("builds PokeAPI sprite URLs for generation one games and wraps them", async () => {
+            const red = await getPokemonImage({
+                species: "Pikachu",
+                name: imageGame("Red"),
+                style: imageStyle({ spritesMode: true }),
+            });
+            const yellow = await getPokemonImage({
+                species: "Pikachu",
+                name: imageGame("Yellow"),
+                style: imageStyle({ spritesMode: true }),
+            });
+
+            expect(red).toBe(
+                "cors(https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/red-blue/transparent/25.png)",
+            );
+            expect(yellow).toBe(
+                "cors(https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/yellow/transparent/25.png)",
+            );
+        });
+
         it("builds Scarlet/Violet sprite URLs and wraps them", async () => {
             const nonShiny = await getPokemonImage({
                 species: "Pikachu",
@@ -408,4 +428,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -180,6 +180,17 @@ export async function getPokemonImage({
 
     if (
         style?.spritesMode &&
+        (name === "Red" || name === "Blue" || name === "Yellow")
+    ) {
+        const version = name === "Yellow" ? "yellow" : "red-blue";
+        const url =
+            `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-i/${version}/transparent/${regularNumber}.png`;
+
+        return await wrapImageInCORS(url);
+    }
+
+    if (
+        style?.spritesMode &&
         (name === "Black" ||
             name === "Emerald" ||
             name === "Ruby" ||


### PR DESCRIPTION
## Summary
- render Champion sprite backgrounds on a span instead of an empty img element
- use PokeAPI generation one sprite URLs for Red, Blue, and Yellow sprite mode
- add regression coverage for Champion sprite markup and Gen 1 sprite URLs

Fixes #1057

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- Playwright smoke on the issue state with `useSpritesForChampsPokemon: true`: 18 Champion sprite nodes rendered as spans with concrete PokeAPI sprite background URLs, no page errors
Fixes #505