### PR TITLE
Add movable box reordering

### DIFF
--- a/src/actions/addBox.ts
+++ b/src/actions/addBox.ts
@@ -36,3 +36,21 @@ export function updateBoxes(): Action<UPDATE_BOXES> {
         type: UPDATE_BOXES,
     };
 }
+
+export type REORDER_BOXES = "REORDER_BOXES";
+export const REORDER_BOXES: REORDER_BOXES = "REORDER_BOXES";
+
+export type reorderBoxes = (
+    draggedId: number,
+    targetId: number,
+) => Action<REORDER_BOXES>;
+export function reorderBoxes(
+    draggedId: number,
+    targetId: number,
+): Action<REORDER_BOXES> {
+    return {
+        type: REORDER_BOXES,
+        draggedId,
+        targetId,
+    };
+}

--- a/src/components/Editors/PokemonEditor/PokemonEditor.tsx
+++ b/src/components/Editors/PokemonEditor/PokemonEditor.tsx
@@ -46,10 +46,10 @@ export class BoxesComponent extends React.Component<BoxesComponentProps> {
     private renderBoxes(boxes: Boxes, team: Pokemon[]) {
         const { matchedIds, hasSearchQuery, searchTerm } = this.props;
 
-        return boxes
+        return [...boxes]
             .sort((a: BoxModel, b: BoxModel) => {
-                const positionA = a.position || 0;
-                const positionB = b.position || 1;
+                const positionA = a.position ?? 0;
+                const positionB = b.position ?? 1;
                 return positionA - positionB;
             })
             .map((box) => {

--- a/src/components/Pokemon/Box/Box.tsx
+++ b/src/components/Pokemon/Box/Box.tsx
@@ -8,6 +8,7 @@ import {
     editBox,
     deleteBox,
     deletePokemon,
+    reorderBoxes,
     updateBoxes,
 } from "actions";
 import { Box as BoxType } from "models";
@@ -157,20 +158,10 @@ export const Box: React.FC<BoxProps> = (props) => {
             if (itemType === "BOX") {
                 const boxItem = item as { id: number; position: number };
                 if (props.id == null || boxItem.id == null || boxItem.id === props.id) {
-                    return; // Don't swap with self
+                    return;
                 }
-                
-                // Swap positions between the two boxes
-                dispatch(
-                    editBox(props.id, {
-                        position: boxItem.position,
-                    }),
-                );
-                dispatch(
-                    editBox(boxItem.id, {
-                        position: props.position,
-                    }),
-                );
+
+                dispatch(reorderBoxes(boxItem.id, props.id));
             }
         },
         collect: (monitor) => ({
@@ -360,6 +351,7 @@ export const Box: React.FC<BoxProps> = (props) => {
                             borderRadius: "0.125rem",
                         }}
                         title="Drag to reorder"
+                        aria-label={`Drag ${name} box to reorder`}
                     >
                         <Icon style={{ opacity: 0.5 }} icon="drag-handle-vertical" />
                     </span>

--- a/src/reducers/__tests__/box.test.ts
+++ b/src/reducers/__tests__/box.test.ts
@@ -1,0 +1,44 @@
+import { editBox, reorderBoxes } from "actions";
+import { Boxes } from "models";
+
+import { box } from "../box";
+
+describe("box", () => {
+    const boxes = (): Boxes => [
+        { id: 0, name: "Team", position: 0 },
+        { id: 1, name: "Boxed", position: 1 },
+        { id: 2, name: "Dead", position: 2 },
+        { id: 3, name: "Champs", position: 3 },
+    ];
+
+    it("preserves array order when editing a box", () => {
+        const subject = box(boxes(), editBox(1, { collapsed: true }));
+
+        expect(subject.map(({ name }) => name)).toEqual([
+            "Team",
+            "Boxed",
+            "Dead",
+            "Champs",
+        ]);
+        expect(subject[1]).toMatchObject({ name: "Boxed", collapsed: true });
+    });
+
+    it("moves a dragged box to the target box position", () => {
+        const subject = box(boxes(), reorderBoxes(1, 3));
+
+        expect(subject.map(({ name }) => name)).toEqual([
+            "Team",
+            "Dead",
+            "Champs",
+            "Boxed",
+        ]);
+        expect(subject.map(({ position }) => position)).toEqual([0, 1, 2, 3]);
+    });
+
+    it("returns the same state for an invalid reorder", () => {
+        const state = boxes();
+
+        expect(box(state, reorderBoxes(99, 3))).toBe(state);
+        expect(box(state, reorderBoxes(1, 1))).toBe(state);
+    });
+});

--- a/src/reducers/box.ts
+++ b/src/reducers/box.ts
@@ -7,8 +7,9 @@ import {
     ADD_BOX,
     DELETE_BOX,
     UPDATE_BOXES,
+    REORDER_BOXES,
 } from "actions";
-import { Boxes } from "models";
+import { Box, Boxes } from "models";
 
 const defaultBoxes: Boxes = [
     {
@@ -33,6 +34,24 @@ const defaultBoxes: Boxes = [
     },
 ];
 
+const getBoxPosition = (box: Box, index: number) => box.position ?? index;
+
+const sortBoxesByPosition = (boxes: Boxes) =>
+    boxes
+        .map((box, index) => ({ box, index }))
+        .sort((a, b) => {
+            const positionA = getBoxPosition(a.box, a.index);
+            const positionB = getBoxPosition(b.box, b.index);
+            return positionA - positionB || a.index - b.index;
+        })
+        .map(({ box }) => box);
+
+const normalizeBoxPositions = (boxes: Boxes) =>
+    sortBoxesByPosition(boxes).map((box, position) => ({
+        ...box,
+        position,
+    }));
+
 export function box(
     state = defaultBoxes,
     action: Action<
@@ -43,6 +62,7 @@ export function box(
         | ADD_BOX
         | DELETE_BOX
         | UPDATE_BOXES
+        | REORDER_BOXES
     >,
 ) {
     switch (action.type) {
@@ -52,7 +72,7 @@ export function box(
                 return state;
             }
             const newBox = { ...box, ...action.edits };
-            return [...state.filter((box) => box.id !== action.id), newBox];
+            return state.map((box) => (box.id === action.id ? newBox : box));
         }
         case REPLACE_STATE:
             return action.replaceWith.box;
@@ -69,6 +89,31 @@ export function box(
         }
         case DELETE_BOX:
             return state.filter((box) => box.id !== action.id);
+        case REORDER_BOXES: {
+            const orderedBoxes = normalizeBoxPositions(state);
+            const draggedIndex = orderedBoxes.findIndex(
+                (box) => box.id === action.draggedId,
+            );
+            const targetIndex = orderedBoxes.findIndex(
+                (box) => box.id === action.targetId,
+            );
+            if (
+                draggedIndex === -1 ||
+                targetIndex === -1 ||
+                draggedIndex === targetIndex
+            ) {
+                return state;
+            }
+
+            const reorderedBoxes = [...orderedBoxes];
+            const [draggedBox] = reorderedBoxes.splice(draggedIndex, 1);
+            reorderedBoxes.splice(targetIndex, 0, draggedBox);
+
+            return reorderedBoxes.map((box, position) => ({
+                ...box,
+                position,
+            }));
+        }
         case UPDATE_BOXES:
             if (state[0].position == null) {
                 return state.map((box, index) => ({


### PR DESCRIPTION
## Summary
- add a dedicated `REORDER_BOXES` action for moving one box to another box position
- keep box edits from reshuffling the boxes array as a side effect
- render boxes from a sorted copy so position sorting does not mutate state
- add reducer coverage for edit-order preservation and box reordering

Fixes #1056

## Validation
- npm run lint
- npm run typecheck
- npm run test:run -- src/reducers/__tests__/box.test.ts
- npm run test:run
- npm run build
- Playwright smoke on local Vite: dragged the Boxed handle onto Champs, confirmed order changed from `Team, Boxed, Dead, Champs` to `Team, Dead, Champs, Boxed`, then reloaded and confirmed the reordered box order persisted