### PR TITLE
Sync current save data from DataEditor

### DIFF
--- a/src/components/Editors/DataEditor/DataEditor.tsx
+++ b/src/components/Editors/DataEditor/DataEditor.tsx
@@ -15,7 +15,7 @@ import { PokemonIcon } from "components/Pokemon/PokemonIcon";
 import { ErrorBoundary, HotkeyIndicator } from "components/Common/Shared";
 import { v4 as uuid } from "uuid";
 import { persistor } from "store";
-import { newNuzlocke, replaceState } from "actions";
+import { newNuzlocke, replaceState, updateNuzlocke } from "actions";
 import { Badge, Game, Pokemon, Trainer } from "models";
 import { BaseEditor } from "components/Editors/BaseEditor/BaseEditor";
 import { State } from "state";
@@ -48,6 +48,7 @@ export interface DataEditorProps {
     state: State;
     replaceState: replaceState;
     newNuzlocke: newNuzlocke;
+    updateNuzlocke: updateNuzlocke;
 }
 
 export interface DataEditorState {
@@ -296,6 +297,13 @@ export class DataEditorBase extends React.Component<
         });
     };
 
+    private syncCurrentNuzlocke = (state: State = this.props.state) => {
+        const currentId = this.props.state.nuzlockes.currentId;
+        if (!currentId) return;
+
+        this.props.updateNuzlocke(currentId, serializeNuzlockeJson(state));
+    };
+
     private confirmImport = () => {
         let cmm: { customMoveMap: State["customMoveMap"] } = {
             customMoveMap: [],
@@ -316,13 +324,14 @@ export class DataEditorBase extends React.Component<
         } else {
             cmm = { customMoveMap: data.customMoveMap };
         }
-        this.props.replaceState({
+        const newState = {
             ...safeguards,
             ...(override ? data : nuz),
             ...cmm,
-        });
+        };
+        this.props.replaceState(newState);
         this.props.newNuzlocke(this.state.data, { isCopy: false });
-        this.writeAllData();
+        this.writeAllData(newState as State);
         this.setState({ isOpen: false });
     };
 
@@ -419,7 +428,7 @@ export class DataEditorBase extends React.Component<
         const t0 = performance.now();
         const worker = new SaveFileWorker();
         const reader = new FileReader();
-        const { replaceState, state } = this.props;
+        const { replaceState, state, updateNuzlocke } = this.props;
         const { selectedGame, boxMappings, mergeDataMode } = settings;
 
         console.log(file, reader, settings, worker);
@@ -490,6 +499,12 @@ export class DataEditorBase extends React.Component<
 
                 const newState = { ...state, ...data, style: nextStyle };
                 replaceState(newState);
+                if (state.nuzlockes.currentId) {
+                    updateNuzlocke(
+                        state.nuzlockes.currentId,
+                        serializeNuzlockeJson(newState),
+                    );
+                }
                 if (result.detectedGame) {
                     showToast({
                         message: `Detected game: ${result.detectedGame.name}`,
@@ -518,7 +533,8 @@ export class DataEditorBase extends React.Component<
         window.location.reload();
     };
 
-    private writeAllData = () => {
+    private writeAllData = (state: State = this.props.state) => {
+        this.syncCurrentNuzlocke(state);
         Promise.resolve(persistor.flush())
             .then(() => {
                 showToast({
@@ -622,6 +638,7 @@ export class DataEditorBase extends React.Component<
         const mergedPokemon = [...existingPokemon, ...newPokemon];
         const newState = { ...state, pokemon: mergedPokemon };
         replaceState(newState);
+        this.syncCurrentNuzlocke(newState);
 
         showToast({
             message: `Imported ${newPokemon.length} Pokemon from Showdown format!`,
@@ -926,7 +943,7 @@ export class DataEditorBase extends React.Component<
                     <ButtonGroup>
                         <Button
                             intent={Intent.SUCCESS}
-                            onClick={this.writeAllData}
+                            onClick={() => this.writeAllData()}
                             icon="floppy-disk"
                         >
                             Force Save{" "}
@@ -961,4 +978,5 @@ export class DataEditorBase extends React.Component<
 export const DataEditor = connect((state: State) => ({ state: state }), {
     replaceState,
     newNuzlocke,
+    updateNuzlocke,
 })(DataEditorBase);

--- a/src/utils/__tests__/nuzlockeJson.test.ts
+++ b/src/utils/__tests__/nuzlockeJson.test.ts
@@ -39,6 +39,7 @@ describe("nuzlocke.json export compatibility", () => {
         const exported = stripEditorDarkModeForExport(state) as Partial<State>;
 
         expect(exported.editorHistory).toBeUndefined();
+        expect(exported.nuzlockes).toBeUndefined();
         expect(exported.pokemon).toEqual(state.pokemon);
         expect(exported.trainer).toEqual(state.trainer);
         expect(exported.style).toMatchObject({

--- a/src/utils/nuzlockeJson.ts
+++ b/src/utils/nuzlockeJson.ts
@@ -4,7 +4,7 @@ import { omit } from "ramda";
 
 export const stripEditorDarkModeForExport = (state: State) => {
     const baseState = omit(
-        ["router", "._persist", "_persist", "editorHistory"],
+        ["router", "._persist", "_persist", "editorHistory", "nuzlockes"],
         state,
     ) as {
         style?: Styles;


### PR DESCRIPTION
## Summary
- make DataEditor Force Save refresh the current `nuzlockes.saves` entry from the visible current state
- sync the current save snapshot after raw save-file and Showdown imports
- keep exported nuzlocke JSON/save snapshots from embedding the `nuzlockes` collection

Fixes #1050
Fixes #990
Fixes #936

## Validation
- npm run lint
- npm run typecheck
- npm run test:run -- src/utils/__tests__/nuzlockeJson.test.ts src/store/__tests__/persistence.test.ts
- npm run test:run
- npm run build
- Playwright smoke on local Vite: seeded localStorage with a Gold top-level run and stale current save data for `None`, clicked Force Save, then confirmed the nested current save data updated to Gold with Quilava and no embedded `nuzlockes` field
- Rechecked remote checks for #990/#936 coverage on 2026-05-28: `check-slug-size`, `validate`, `Vercel`, and `Vercel Preview Comments` are passing.
Fixes #492
Fixes #541
