### PR TITLE
Add Pokemon characteristic field

### DIFF
--- a/src/components/Editors/DataEditor/DataEditor.tsx
+++ b/src/components/Editors/DataEditor/DataEditor.tsx
@@ -574,6 +574,7 @@ export class DataEditorBase extends React.Component<
         const hasNoItem = !pokemon.item;
         const hasNoMoves = !pokemon.moves || pokemon.moves.length === 0;
         const hasNoAbility = !pokemon.ability;
+        const hasNoCharacteristic = !pokemon.characteristic;
         const hasNoCustomizations =
             !pokemon.customImage && !pokemon.customIcon && !pokemon.notes;
 
@@ -583,6 +584,7 @@ export class DataEditorBase extends React.Component<
             hasNoItem &&
             hasNoMoves &&
             hasNoAbility &&
+            hasNoCharacteristic &&
             hasNoCustomizations
         );
     };

--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -718,6 +718,14 @@ export class CurrentPokemonEditBase extends React.Component<
                         pokemon={currentPokemon}
                         key={this.state.selectedId + "nature"}
                     />
+                    <CurrentPokemonInput
+                        labelName="Characteristic"
+                        inputName="characteristic"
+                        placeholder="Alert to sounds"
+                        value={currentPokemon.characteristic}
+                        type="text"
+                        key={this.state.selectedId + "characteristic"}
+                    />
                     <Autocomplete
                         items={listOfAbilities}
                         name="ability"

--- a/src/components/Editors/PokemonEditor/SearchHelpPopover.tsx
+++ b/src/components/Editors/PokemonEditor/SearchHelpPopover.tsx
@@ -189,6 +189,7 @@ const SearchHelpContent: React.FC = () => (
                     "item",
                     "ability",
                     "nature",
+                    "characteristic",
                     "forme",
                     "game",
                     "shiny",

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -245,6 +245,11 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                                 <strong>{pokemon.nature}</strong> nature
                             </div>
                         ) : null}
+                        {pokemon.characteristic ? (
+                            <div className="pokemon-characteristic">
+                                {pokemon.characteristic}
+                            </div>
+                        ) : null}
                         {pokemon.ability ? (
                             <div className="pokemon-ability">
                                 {pokemon.ability}
@@ -486,6 +491,7 @@ export class TeamPokemonBase extends React.Component<
             "level",
             "metLevel",
             "nature",
+            "characteristic",
             "ability",
             "item",
             "types",

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
@@ -72,6 +72,7 @@ const basePokemon: Pokemon = {
     level: 10,
     types: [Types.Grass, Types.Poison],
     ability: "Overgrow",
+    characteristic: "Alert to sounds",
     moves: ["Tackle", "Growl"],
 };
 
@@ -91,6 +92,7 @@ describe("TeamPokemonBase", () => {
         expect(screen.getByText("Bulby")).toBeTruthy();
         expect(screen.getByText("Bulbasaur")).toBeTruthy();
         expect(screen.getByText(/lv\. 10/i)).toBeTruthy();
+        expect(screen.getByText("Alert to sounds")).toBeTruthy();
     });
 
     it("invokes selectPokemon when the image wrapper is clicked", () => {

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -12,6 +12,7 @@ export interface Pokemon {
     met?: string;
     metLevel?: number;
     nature?: string;
+    characteristic?: string;
     ability?: string;
     moves?: string[];
     causeOfDeath?: string;
@@ -54,6 +55,7 @@ export const PokemonKeys: Pokemon = {
     met: "",
     metLevel: 0,
     nature: "",
+    characteristic: "",
     ability: "",
     moves: [],
     causeOfDeath: "",

--- a/src/utils/generateEmptyPokemon.ts
+++ b/src/utils/generateEmptyPokemon.ts
@@ -37,6 +37,7 @@ export function generateEmptyPokemon(
         met: "",
         metLevel: undefined,
         nature: "None",
+        characteristic: "",
         ability: "",
         types: [Types.Normal, Types.Normal],
         egg: false,

--- a/src/utils/search/__tests__/search.test.ts
+++ b/src/utils/search/__tests__/search.test.ts
@@ -343,6 +343,23 @@ describe("searchPokemon", () => {
         expect(matchedIds.size).toBe(4);
     });
 
+    it("filters by characteristic", () => {
+        const { matchedIds } = searchPokemon(
+            [
+                ...testTeam,
+                createPokemon({
+                    id: "8",
+                    species: "Raichu",
+                    characteristic: "Alert to sounds",
+                }),
+            ],
+            "characteristic:sounds",
+        );
+
+        expect(matchedIds.size).toBe(1);
+        expect(matchedIds.has("8")).toBe(true);
+    });
+
     it("filters by negation", () => {
         const { matchedIds } = searchPokemon(testTeam, "!species:Bulbasaur");
         expect(matchedIds.size).toBe(6);

--- a/src/utils/search/normalize.ts
+++ b/src/utils/search/normalize.ts
@@ -37,6 +37,7 @@ export function normalizePokemon(pokemon: Pokemon): NormalizedPokemon {
         item: normalizeString(pokemon.item),
         ability: normalizeString(pokemon.ability),
         nature: normalizeString(pokemon.nature),
+        characteristic: normalizeString(pokemon.characteristic),
         level: pokemon.level ?? 0,
         metLevel: pokemon.metLevel ?? 0,
         status: normalizeString(pokemon.status),
@@ -98,5 +99,4 @@ export function clearNormalizationCache(): void {
     // WeakMap doesn't have a clear method, so we just create a new one
     // This function exists for API consistency but the WeakMap handles cleanup automatically
 }
-
 

--- a/src/utils/search/types.ts
+++ b/src/utils/search/types.ts
@@ -123,6 +123,7 @@ export interface NormalizedPokemon {
     item: string; // lowercase
     ability: string; // lowercase
     nature: string; // lowercase
+    characteristic: string; // lowercase
     level: number;
     metLevel: number;
     status: string; // lowercase (box name)
@@ -166,6 +167,8 @@ export const FIELD_ALIASES: Record<string, keyof NormalizedPokemon> = {
     item: "item",
     ability: "ability",
     nature: "nature",
+    characteristic: "characteristic",
+    char: "characteristic",
     level: "level",
     lvl: "level",
     lv: "level",
@@ -207,5 +210,4 @@ export const BOOLEAN_FIELDS = new Set<string>([
 
 /** Fields that are numeric */
 export const NUMERIC_FIELDS = new Set<string>(["level", "metLevel"]);
-
 


### PR DESCRIPTION
## Summary
- add a `characteristic` field to Pokemon data and empty Pokemon defaults
- expose Characteristic in the Pokemon editor and render it on team cards
- include characteristics in result data attributes and search field filters
- add regression coverage for rendering and search

Fixes #1047

## Validation
- npm run lint
- npm run typecheck
- npm run test:run -- src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx src/utils/search/__tests__/search.test.ts
- npm run test:run
- npm run build
- Playwright smoke on local Vite: seeded a selected Bulbasaur with `characteristic: Alert to sounds`, confirmed the editor input and team card render it, edited it to `Likes to relax`, and confirmed persisted Pokemon state plus page text updated