### PR TITLE
Add static encounter marker

### DIFF
--- a/src/components/Editors/DataEditor/DataEditor.tsx
+++ b/src/components/Editors/DataEditor/DataEditor.tsx
@@ -575,7 +575,10 @@ export class DataEditorBase extends React.Component<
         const hasNoMoves = !pokemon.moves || pokemon.moves.length === 0;
         const hasNoAbility = !pokemon.ability;
         const hasNoCustomizations =
-            !pokemon.customImage && !pokemon.customIcon && !pokemon.notes;
+            !pokemon.customImage &&
+            !pokemon.customIcon &&
+            !pokemon.notes &&
+            !pokemon.staticEncounter;
 
         return (
             isSpeciesEmpty &&

--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -340,6 +340,13 @@ export class CurrentPokemonEditBase extends React.Component<
                         key={this.state.selectedId + "gift"}
                     />
                     <CurrentPokemonInput
+                        labelName="Static"
+                        inputName="staticEncounter"
+                        value={currentPokemon?.staticEncounter}
+                        type="checkbox"
+                        key={this.state.selectedId + "staticEncounter"}
+                    />
+                    <CurrentPokemonInput
                         labelName="Alpha"
                         inputName="alpha"
                         value={currentPokemon?.alpha}

--- a/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
+++ b/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
@@ -78,7 +78,12 @@ const LocationIcon = ({
     pokemon: Pokemon[];
     poke?: Pokemon;
 }) => {
-    if (poke && !poke.hidden && (!poke.gift || !excludeGifts)) {
+    if (
+        poke &&
+        !poke.hidden &&
+        !poke.staticEncounter &&
+        (!poke.gift || !excludeGifts)
+    ) {
         return (
             <>
                 <Icon icon="tick" />
@@ -125,6 +130,7 @@ export const PokemonLocationChecklist = ({
         const counts = new Map<string, number>();
         for (const poke of pokemon) {
             if (!poke || poke.hidden) continue;
+            if (poke.staticEncounter) continue;
             if (currentGame !== "None" && poke.gameOfOrigin !== currentGame)
                 continue;
             if (!encounterSet.has(poke.met)) continue;
@@ -148,6 +154,7 @@ export const PokemonLocationChecklist = ({
         for (const poke of pokemon) {
             const met = poke?.met?.trim();
             if (!met) continue;
+            if (poke.staticEncounter) continue;
             if (currentGame !== "None" && poke.gameOfOrigin !== currentGame)
                 continue;
             const key = met.toLocaleLowerCase();
@@ -312,7 +319,8 @@ export const PokemonLocationChecklist = ({
                 style={{ fontSize: "80%", marginTop: "0.5rem" }}
             >
                 Tip: Pokémon with the &quot;hidden&quot; attribute are a great
-                option for including Pokemon that got away on a certain route!
+                option for including Pokemon that got away on a certain route.
+                Mark static encounters to keep them out of route counts.
             </Callout>
         </div>
     );

--- a/src/components/Editors/PokemonEditor/SearchHelpPopover.tsx
+++ b/src/components/Editors/PokemonEditor/SearchHelpPopover.tsx
@@ -193,6 +193,7 @@ const SearchHelpContent: React.FC = () => (
                     "game",
                     "shiny",
                     "egg",
+                    "static",
                     "alpha",
                     "mvp",
                 ].map((field) => (

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -494,6 +494,7 @@ export class TeamPokemonBase extends React.Component<
             "causeOfDeath",
             "shiny",
             "champion",
+            "staticEncounter",
             "num",
             "wonderTradedFor",
             "mvp",

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -32,6 +32,7 @@ export interface Pokemon {
     gameOfOrigin?: Game;
     egg?: boolean;
     hidden?: boolean;
+    staticEncounter?: boolean;
     extraData?: object;
     pokeball?: string;
     notes?: string;
@@ -75,6 +76,7 @@ export const PokemonKeys: Pokemon = {
     gameOfOrigin: "Red",
     egg: false,
     hidden: false,
+    staticEncounter: false,
     extraData: {},
     pokeball: "None",
     notes: "",

--- a/src/utils/generateEmptyPokemon.ts
+++ b/src/utils/generateEmptyPokemon.ts
@@ -41,6 +41,7 @@ export function generateEmptyPokemon(
         types: [Types.Normal, Types.Normal],
         egg: false,
         gift: false,
+        staticEncounter: false,
         ...(overrides ?? {}),
     };
 }

--- a/src/utils/search/__tests__/search.test.ts
+++ b/src/utils/search/__tests__/search.test.ts
@@ -25,6 +25,7 @@ const createPokemon = (overrides: Partial<Pokemon> = {}): Pokemon => ({
     alpha: false,
     mvp: false,
     gift: false,
+    staticEncounter: false,
     ...overrides,
 });
 
@@ -341,6 +342,23 @@ describe("searchPokemon", () => {
     it("filters by gender", () => {
         const { matchedIds } = searchPokemon(testTeam, "gender:f");
         expect(matchedIds.size).toBe(4);
+    });
+
+    it("filters by static encounters", () => {
+        const { matchedIds } = searchPokemon(
+            [
+                ...testTeam,
+                createPokemon({
+                    id: "8",
+                    species: "Snorlax",
+                    staticEncounter: true,
+                }),
+            ],
+            "static:true",
+        );
+
+        expect(matchedIds.size).toBe(1);
+        expect(matchedIds.has("8")).toBe(true);
     });
 
     it("filters by negation", () => {

--- a/src/utils/search/normalize.ts
+++ b/src/utils/search/normalize.ts
@@ -45,6 +45,7 @@ export function normalizePokemon(pokemon: Pokemon): NormalizedPokemon {
         shiny: Boolean(pokemon.shiny),
         egg: Boolean(pokemon.egg),
         hidden: Boolean(pokemon.hidden),
+        staticEncounter: Boolean(pokemon.staticEncounter),
         alpha: Boolean(pokemon.alpha),
         mvp: Boolean(pokemon.mvp),
         gift: Boolean(pokemon.gift),
@@ -98,5 +99,4 @@ export function clearNormalizationCache(): void {
     // WeakMap doesn't have a clear method, so we just create a new one
     // This function exists for API consistency but the WeakMap handles cleanup automatically
 }
-
 

--- a/src/utils/search/types.ts
+++ b/src/utils/search/types.ts
@@ -131,6 +131,7 @@ export interface NormalizedPokemon {
     shiny: boolean;
     egg: boolean;
     hidden: boolean;
+    staticEncounter: boolean;
     alpha: boolean;
     mvp: boolean;
     gift: boolean;
@@ -179,6 +180,8 @@ export const FIELD_ALIASES: Record<string, keyof NormalizedPokemon> = {
     shiny: "shiny",
     egg: "egg",
     hidden: "hidden",
+    static: "staticEncounter",
+    staticencounter: "staticEncounter",
     alpha: "alpha",
     mvp: "mvp",
     gift: "gift",
@@ -200,6 +203,7 @@ export const BOOLEAN_FIELDS = new Set<string>([
     "shiny",
     "egg",
     "hidden",
+    "staticEncounter",
     "alpha",
     "mvp",
     "gift",
@@ -207,5 +211,4 @@ export const BOOLEAN_FIELDS = new Set<string>([
 
 /** Fields that are numeric */
 export const NUMERIC_FIELDS = new Set<string>(["level", "metLevel"]);
-
 


### PR DESCRIPTION
## Summary
- add a `staticEncounter` Pokemon flag with an editor checkbox
- exclude static encounters from location checklist totals and route tick/icon lookup
- expose static encounters in search with `static:true` and data attributes
- add search regression coverage

Fixes #1016
Fixes #989

## Validation
- npm run lint
- npm run typecheck
- npm run test:run -- src/utils/search/__tests__/search.test.ts
- npm run test:run
- npm run build
- Playwright smoke on local Vite: seeded a static Zapdos at custom area `Power Plant`, confirmed the Location Checklist showed the area with no tick/icon while Static was checked, toggled Static off, then confirmed the checklist gained a tick/icon and persisted `staticEncounter: false`
- Rechecked remote checks for #989 coverage on 2026-05-28: `check-slug-size`, `validate`, `Vercel`, and `Vercel Preview Comments` are passing.