### PR TITLE
Fix card item icon overlap with moves

### DIFF
--- a/src/components/Pokemon/TeamPokemon/PokemonItem.tsx
+++ b/src/components/Pokemon/TeamPokemon/PokemonItem.tsx
@@ -4,7 +4,12 @@ import { Pokemon } from "models";
 import { State } from "state";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { ResizedImage } from "components/Common/Shared/ResizedImage";
-import { getBackgroundGradient, getHeldItemIconPath, typeToColor } from "utils";
+import {
+    getBackgroundGradient,
+    getHeldItemIconPath,
+    TemplateName,
+    typeToColor,
+} from "utils";
 
 const itemLabelStyle = {
     base: css`
@@ -35,6 +40,9 @@ const itemLabelStyle = {
         margin: 0;
         bottom: 0.5rem;
     `,
+    ["cards with horizontal moves"]: css`
+        bottom: 3rem;
+    `,
     ["text"]: css`
         display: none !important;
     `,
@@ -50,6 +58,10 @@ export function PokemonItem({
     customTypes: State["customTypes"];
 }) {
     const getSecondType = pokemon?.types?.[1] || "Normal";
+    const liftCardsItemAboveMoves =
+        style.template === TemplateName.Cards &&
+        style.showPokemonMoves &&
+        style.movesPosition === "horizontal";
 
     return (pokemon.item || pokemon.customItemImage) &&
         !style.displayItemAsText ? (
@@ -74,6 +86,12 @@ export function PokemonItem({
             className={cx(
                 itemLabelStyle.base,
                 itemLabelStyle[style.itemStyle],
+                liftCardsItemAboveMoves
+                    ? itemLabelStyle["cards with horizontal moves"]
+                    : undefined,
+                liftCardsItemAboveMoves
+                    ? "pokemon-item--cards-with-horizontal-moves"
+                    : undefined,
                 "pokemon-item",
             )}
         >

--- a/src/components/Pokemon/TeamPokemon/__tests__/PokemonItem.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/PokemonItem.test.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { render, screen } from "utils/testUtils";
+import { Pokemon } from "models";
+import { styleDefaults } from "utils/styleDefaults";
+import { TemplateName, Types } from "utils";
+import { PokemonItem } from "../PokemonItem";
+
+const pokemon: Pokemon = {
+    id: "poke-item-test",
+    species: "Pikachu",
+    item: "Leftovers",
+    types: [Types.Electric, Types.Electric],
+};
+
+describe("PokemonItem", () => {
+    it("lifts cards item icons above horizontal moves", () => {
+        render(
+            <PokemonItem
+                pokemon={pokemon}
+                style={{
+                    ...styleDefaults,
+                    template: TemplateName.Cards,
+                    showPokemonMoves: true,
+                    movesPosition: "horizontal",
+                }}
+                customTypes={[]}
+            />,
+        );
+
+        const item = screen.getByAltText("Leftovers").parentElement;
+        expect(item?.className).toContain(
+            "pokemon-item--cards-with-horizontal-moves",
+        );
+    });
+
+    it("keeps the default item position when cards moves are not horizontal", () => {
+        render(
+            <PokemonItem
+                pokemon={pokemon}
+                style={{
+                    ...styleDefaults,
+                    template: TemplateName.Cards,
+                    showPokemonMoves: true,
+                    movesPosition: "vertical",
+                }}
+                customTypes={[]}
+            />,
+        );
+
+        const item = screen.getByAltText("Leftovers").parentElement;
+        expect(item?.className).not.toContain(
+            "pokemon-item--cards-with-horizontal-moves",
+        );
+    });
+
+    it("keeps the default item position when cards moves are hidden", () => {
+        render(
+            <PokemonItem
+                pokemon={pokemon}
+                style={{
+                    ...styleDefaults,
+                    template: TemplateName.Cards,
+                    showPokemonMoves: false,
+                    movesPosition: "horizontal",
+                }}
+                customTypes={[]}
+            />,
+        );
+
+        const item = screen.getByAltText("Leftovers").parentElement;
+        expect(item?.className).not.toContain(
+            "pokemon-item--cards-with-horizontal-moves",
+        );
+    });
+});


### PR DESCRIPTION
Fixes #1006.

## Summary
- lifts held item icons above the horizontal move strip in the Cards template
- keeps the existing item position for vertical moves and hidden moves
- adds PokemonItem coverage for the Cards + horizontal moves condition

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- Playwright layout smoke on Cards template with Leftovers + four moves: item box y=295..343, moves y=359..391, no overlap with moves/nickname/Poke Ball