### PR TITLE
Add shiny icon next to Pokemon names

### DIFF
--- a/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
+++ b/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
@@ -8,6 +8,7 @@ import { getContrastColor, Styles, gameOfOriginToColor } from "utils";
 import { PokemonIcon } from "components/Pokemon/PokemonIcon/PokemonIcon";
 import { GenderElement } from "components/Common/Shared";
 import { State } from "state";
+import { PokemonShinyIndicator } from "components/Pokemon/PokemonShinyIndicator";
 
 export type BoxedPokemonProps = Pokemon & { selectPokemon: selectPokemon } & {
     style: Styles;
@@ -79,7 +80,9 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
                         data-testid="boxed-pokemon-name"
                         className="boxed-pokemon-name"
                     >
-                        {poke?.nickname} {GenderElement(poke?.gender)}{" "}
+                        {poke?.nickname}
+                        <PokemonShinyIndicator shiny={poke?.shiny} />{" "}
+                        {GenderElement(poke?.gender)}{" "}
                         {poke?.level ? <span>lv. {poke?.level}</span> : null}
                         {poke?.style?.displayGameOriginForBoxedAndDead &&
                             !poke?.style?.displayBackgroundInsteadOfBadge &&

--- a/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
+++ b/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
@@ -18,4 +18,18 @@ describe(BoxedPokemonBase.name, () => {
             PokemonFixtures.Pikachu.nickname,
         );
     });
+
+    it("renders a shiny indicator for shiny boxed pokemon", async () => {
+        // @ts-expect-error - Test props may not match full interface
+        const props: BoxedPokemonProps = {
+            ...PokemonFixtures.Pikachu,
+            shiny: true,
+            style: styleDefaults,
+        };
+
+        render(<BoxedPokemonBase {...props} />);
+
+        await waitFor(() => screen.getByTestId("boxed-pokemon-name"));
+        expect(screen.getByAltText("Shiny")).toBeTruthy();
+    });
 });

--- a/src/components/Pokemon/ChampsPokemon/ChampsPokemon.tsx
+++ b/src/components/Pokemon/ChampsPokemon/ChampsPokemon.tsx
@@ -16,6 +16,7 @@ import { Pokemon } from "models";
 import { GenderElement } from "components/Common/Shared";
 import { css, cx } from "emotion";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
+import { PokemonShinyIndicator } from "components/Pokemon/PokemonShinyIndicator";
 
 type ChampsPokemonStyleOptions = {
     height: string;
@@ -157,6 +158,9 @@ export class ChampsPokemon extends React.Component<ChampsPokemonProps> {
                         style={{ margin: "0 4px" }}
                     >
                         {this.props.showNickname && this.props.nickname}
+                        {this.props.showNickname && (
+                            <PokemonShinyIndicator shiny={this.props.shiny} />
+                        )}
                     </span>
                     {this.props.showGender && GenderElement(this.props.gender)}
                     <span

--- a/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
+++ b/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
@@ -23,6 +23,7 @@ import {
 import { selectPokemon } from "actions";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { State } from "state";
+import { PokemonShinyIndicator } from "components/Pokemon/PokemonShinyIndicator";
 
 const spriteStyle = (style: Styles) => {
     if (style.spritesMode) {
@@ -164,7 +165,9 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                         }}
                     >
                         <div>
-                            {poke.nickname} {GenderElement(poke.gender)} Levels{" "}
+                            {poke.nickname}
+                            <PokemonShinyIndicator shiny={poke.shiny} />{" "}
+                            {GenderElement(poke.gender)} Levels{" "}
                             {poke.metLevel}
                             &mdash;
                             {poke.level}
@@ -237,7 +240,9 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                     }}
                 >
                     <div>
-                        {poke.nickname} {GenderElement(poke.gender)} Levels{" "}
+                        {poke.nickname}
+                        <PokemonShinyIndicator shiny={poke.shiny} />{" "}
+                        {GenderElement(poke.gender)} Levels{" "}
                         {poke.metLevel}&mdash;
                         {poke.level}
                     </div>
@@ -316,7 +321,9 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
             )}
             <div className="dead-pokemon-info">
                 <div className="pokemon-d-nickname">
-                    {poke.nickname} {GenderElement(poke.gender)}
+                    {poke.nickname}
+                    <PokemonShinyIndicator shiny={poke.shiny} />{" "}
+                    {GenderElement(poke.gender)}
                 </div>
                 <div className="pokemon-levels">
                     Levels {poke.metLevel}&mdash;{poke.level}

--- a/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
+++ b/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
@@ -27,4 +27,19 @@ describe("<DeadPokemon />", () => {
             poke.causeOfDeath,
         );
     });
+
+    it("renders a shiny indicator for shiny dead pokemon", () => {
+        render(
+            <DeadPokemonBase
+                game={{ name: "Red", customName: "" }}
+                style={styleDefaults}
+                selectPokemon={vi.fn()}
+                minimal={false}
+                {...poke}
+                shiny
+            />,
+        );
+
+        expect(screen.getByAltText("Shiny")).toBeTruthy();
+    });
 });

--- a/src/components/Pokemon/PokemonShinyIndicator.tsx
+++ b/src/components/Pokemon/PokemonShinyIndicator.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { css } from "emotion";
+import { Pokemon } from "models";
+
+const shinyIndicatorStyle = css`
+    display: inline-block;
+    height: 1rem;
+    margin-left: 0.25rem;
+    vertical-align: -0.15rem;
+    width: 1rem;
+`;
+
+export function PokemonShinyIndicator({
+    shiny,
+}: {
+    shiny?: Pokemon["shiny"];
+}) {
+    if (!shiny) return null;
+
+    return (
+        <img
+            alt="Shiny"
+            className={`pokemon-shiny-indicator ${shinyIndicatorStyle}`}
+            src="icons/key-item/shiny-charm.png"
+            title="Shiny"
+        />
+    );
+}

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -29,6 +29,7 @@ import { PokemonPokeball } from "./PokemonPokeball";
 import { PokemonFriendship } from "./PokemonFriendship";
 import { normalizePokeballName } from "utils";
 import { PokemonExtraDataStats } from "./PokemonExtraDataStats";
+import { PokemonShinyIndicator } from "components/Pokemon/PokemonShinyIndicator";
 
 export interface TeamPokemonInfoProps {
     generation: Generation;
@@ -194,6 +195,9 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                             </span>
                             <span className="pokemon-name">
                                 {!pokemon.egg ? pokemon.species : "???"}
+                                <PokemonShinyIndicator
+                                    shiny={pokemon.shiny}
+                                />
                                 {pokemon.item && style.itemStyle === "text"
                                     ? ` @ ${pokemon.item}`
                                     : null}
@@ -385,6 +389,7 @@ export function TeamPokemonBaseMinimal(
                     <span className="pokemon-nickname">{pokemon.nickname}</span>
                     <span className="pokemon-name">
                         {!pokemon.egg ? pokemon.species : "???"}
+                        <PokemonShinyIndicator shiny={pokemon.shiny} />
                     </span>
                     {pokemon.level ? (
                         <span className="pokemon-level">

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
@@ -165,6 +165,36 @@ describe("TeamPokemonBase", () => {
         expect(screen.getByAltText("Tera: Fire")).toBeTruthy();
     });
 
+    it("renders a shiny indicator next to the pokemon name when shiny", () => {
+        render(
+            <TeamPokemonInfo
+                generation={Generation.Gen3}
+                style={baseStyle}
+                pokemon={{ ...basePokemon, shiny: true }}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        expect(screen.getByAltText("Shiny")).toBeTruthy();
+    });
+
+    it("omits the shiny indicator for non-shiny pokemon", () => {
+        render(
+            <TeamPokemonInfo
+                generation={Generation.Gen3}
+                style={baseStyle}
+                pokemon={{ ...basePokemon, shiny: false }}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        expect(screen.queryByAltText("Shiny")).toBeNull();
+    });
+
     it("uses minimal layout when enabled", () => {
         const minimalStyle = { ...baseStyle, minimalTeamLayout: true };
 


### PR DESCRIPTION
Fixes #1005.
Fixes #1004.

## Summary
- adds a reusable shiny-name indicator using the existing shiny charm icon asset
- renders the indicator beside shiny Pokemon names in team, boxed, dead, and champion result displays
- keeps non-shiny Pokemon name output unchanged

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- Playwright result smoke: shiny Pikachu shows an inline `.pokemon-shiny-indicator` next to `.pokemon-name`, icon loads from `icons/key-item/shiny-charm.png` at natural width 32; non-shiny state renders zero shiny indicators