### PR TITLE
Fix Sword Shield Obstagoon sprite URL

### DIFF
--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => {
                 Unfezant: 521,
                 Gyarados: 130,
                 Dugtrio: 51,
+                Obstagoon: 862,
                 Indeedee: 876,
                 Basculegion: 902,
                 "Mime Jr.": 439,
@@ -281,6 +282,30 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             );
         });
 
+        it("omits the Galarian suffix for Obstagoon Sword/Shield sprites", async () => {
+            const nonShiny = await getPokemonImage({
+                species: "Obstagoon",
+                forme: imageForme("Galarian"),
+                name: imageGame("Sword"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: false,
+            });
+            const shiny = await getPokemonImage({
+                species: "Obstagoon",
+                forme: imageForme("Galarian"),
+                name: imageGame("Shield"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: true,
+            });
+
+            expect(nonShiny).toBe(
+                "cors(https://www.serebii.net/swordshield/pokemon/862.png)",
+            );
+            expect(shiny).toBe(
+                "cors(https://www.serebii.net/Shiny/SWSH/862.png)",
+            );
+        });
+
         it("uses generic serebii URL builder for other games when spritesMode is true", async () => {
             const result = await getPokemonImage({
                 species: "Pikachu",
@@ -408,4 +433,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -126,6 +126,19 @@ const getGameNameSerebii = (name: Game) => {
     }
 };
 
+const getSWSHForme = (
+    species: GetPokemonImage["species"],
+    forme: GetPokemonImage["forme"],
+) => {
+    // Obstagoon is already the Galarian evolution line's final form, so Serebii
+    // stores its Sword/Shield sprite as 862.png rather than 862-g.png.
+    if (species === "Obstagoon" && forme === "Galarian") {
+        return undefined;
+    }
+
+    return forme;
+};
+
 export interface GetPokemonImage {
     customImage?: string;
     forme?: Pokemon["forme"] | keyof typeof Forme;
@@ -259,7 +272,9 @@ export async function getPokemonImage({
         if (!shiny) {
             const url = `https://www.serebii.net/${getGameName(
                 name,
-            )}/pokemon/${leadingZerosNumber}${getForme(forme)}.png`;
+            )}/pokemon/${leadingZerosNumber}${getForme(
+                getSWSHForme(species, forme),
+            )}.png`;
 
             return await wrapImageInCORS(url);
         }


### PR DESCRIPTION
Fixes #1001.
Fixes #818.

## Summary
- keeps Sword/Shield sprite-mode shiny URLs on the existing SWSH shiny path
- prevents Obstagoon with `forme: Galarian` from requesting the broken `862-g.png` sprite
- adds regression coverage for non-shiny and shiny Obstagoon Sword/Shield sprite URLs

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts
- curl URL audit: `swordshield/pokemon/862-g.png` returns 404; `swordshield/pokemon/862.png`, `Shiny/SWSH/862.png`, and `Shiny/SWSH/025.png` return image/png
- Playwright issue-state smoke: Obstagoon with `forme: Galarian` renders `https://www.serebii.net/swordshield/pokemon/862.png`; shiny Obstagoon renders `https://www.serebii.net/Shiny/SWSH/862.png`