### PR TITLE
Fix Paldean Tauros form icons

### DIFF
--- a/src/components/Pokemon/PokemonIcon/__tests__/PokemonIcon.test.tsx
+++ b/src/components/Pokemon/PokemonIcon/__tests__/PokemonIcon.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { Forme } from "utils";
+import { getIconURL } from "../PokemonIcon";
+
+describe("getIconURL", () => {
+    it("builds Paldean Tauros icon URLs for each breed", () => {
+        expect(
+            getIconURL({
+                id: "paldean",
+                species: "Tauros",
+                forme: Forme.Paldean,
+            }),
+        ).toEqual("icons/pokemon/regular/tauros-paldea.png");
+        expect(
+            getIconURL({
+                id: "paldean-aqua",
+                species: "Tauros",
+                forme: Forme["Paldean-Aqua"],
+            }),
+        ).toEqual("icons/pokemon/regular/tauros-paldea-aqua.png");
+        expect(
+            getIconURL({
+                id: "paldean-blaze",
+                species: "Tauros",
+                forme: Forme["Paldean-Blaze"],
+            }),
+        ).toEqual("icons/pokemon/regular/tauros-paldea-blaze.png");
+    });
+});

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -45,6 +45,15 @@ describe("addForme", () => {
         const forme = addForme("alakazam", "Mega");
         expect(forme).toEqual("alakazam-mega");
     });
+    it("returns paldean Tauros formes", () => {
+        expect(addForme("tauros", "Paldean")).toEqual("paldean-tauros");
+        expect(addForme("tauros", "Paldean-Aqua")).toEqual(
+            "paldean-aqua-tauros",
+        );
+        expect(addForme("tauros", "Paldean-Blaze")).toEqual(
+            "paldean-blaze-tauros",
+        );
+    });
 });
 
 describe("choose", () => {

--- a/src/utils/addForme.ts
+++ b/src/utils/addForme.ts
@@ -18,7 +18,7 @@ export const addForme = (
             return `paldean-${species}`;
         }
         if (forme === "Paldean-Aqua") {
-            return `palden-aqua-${species}`;
+            return `paldean-aqua-${species}`;
         }
         if (forme === "Paldean-Blaze") {
             return `paldean-blaze-${species}`;

--- a/src/utils/getters/getIconFormeSuffix.ts
+++ b/src/utils/getters/getIconFormeSuffix.ts
@@ -1,10 +1,17 @@
 import { Forme } from "utils";
 
-export const getIconFormeSuffix = (forme: keyof typeof Forme) => {
-    console.log(forme);
+type FormeKey = keyof typeof Forme;
+
+const getFormeKey = (forme: FormeKey | Forme): FormeKey | undefined =>
+    (Object.entries(Forme) as Array<[FormeKey, Forme]>).find(
+        ([key, value]) => key === forme || value === forme,
+    )?.[0];
+
+export const getIconFormeSuffix = (forme?: FormeKey | Forme) => {
     if (forme == null) return "";
-    if (forme === "Normal") return "";
-    if (forme === "Spring") return "";
+    const formeKey = getFormeKey(forme) ?? forme;
+    if (formeKey === "Normal") return "";
+    if (formeKey === "Spring") return "";
     if (
         [
             "Heat",
@@ -15,14 +22,14 @@ export const getIconFormeSuffix = (forme: keyof typeof Forme) => {
             "Summer",
             "Winter",
             "Autumn",
-        ].includes(forme)
+        ].includes(formeKey)
     )
-        return `-${forme.toLowerCase()}`;
-    if (forme === "10%") return "-10-percent";
-    if (forme === "Complete") return "-complete";
-    if (forme === "!") return "-exclamation";
-    if (forme === "?") return "-question";
-    if (forme === "EternalFlower") return "-eternal";
-    if (Forme[forme]) return `-${Forme[forme]}`;
+        return `-${formeKey.toLowerCase()}`;
+    if (formeKey === "10%") return "-10-percent";
+    if (formeKey === "Complete") return "-complete";
+    if (formeKey === "!") return "-exclamation";
+    if (formeKey === "?") return "-question";
+    if (formeKey === "EternalFlower") return "-eternal";
+    if (Forme[formeKey]) return `-${Forme[formeKey]}`;
     return "";
 };


### PR DESCRIPTION
Fixes #1000
Fixes #947

## Summary
- normalize icon forme suffixes so enum values like `paldea-aqua` resolve to Paldean Tauros icon filenames
- fix the Paldean-Aqua `addForme` typo for non-icon image paths
- add regressions for Paldean, Paldean-Aqua, and Paldean-Blaze Tauros icon URLs and forme names

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- Browser smoke on Vite port 18109: seeded three Team Tauros with `forme` values `paldea`, `paldea-aqua`, and `paldea-blaze`; confirmed rendered `.pokemon-icon-main img` srcs were `icons/pokemon/regular/tauros-paldea.png`, `icons/pokemon/regular/tauros-paldea-aqua.png`, and `icons/pokemon/regular/tauros-paldea-blaze.png`