### PR TITLE
Fix Lycanroc and Alolan Muk data

### DIFF
--- a/src/utils/Forme.ts
+++ b/src/utils/Forme.ts
@@ -88,6 +88,10 @@ export enum Forme {
     "East Sea" = "east",
     "West Sea" = "west",
 
+    Midday = "midday",
+    Midnight = "midnight",
+    Dusk = "dusk",
+
     Lowkey = "lowkey",
     AmpedUp = "amped",
 

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import {
     Generation,
     typeToColor,
     isEmpty,
+    getIconFormeSuffix,
 } from "utils";
 import * as React from "react";
 import * as Color from "color";
@@ -107,6 +108,10 @@ describe("matchSpeciesToType", () => {
             "Steel",
             "Steel",
         ]);
+        expect(matchSpeciesToTypes("Muk", "Alolan")).toEqual([
+            "Poison",
+            "Dark",
+        ]);
         expect(matchSpeciesToTypes("Shaymin", "Sky")).toEqual([
             "Grass",
             "Flying",
@@ -123,6 +128,14 @@ describe("matchSpeciesToType", () => {
         console.log(noMatches.length);
         console.log(noMatches);
         expect(false).toBe(true);
+    });
+});
+
+describe(getIconFormeSuffix.name, () => {
+    it("builds Lycanroc icon suffixes for each forme", () => {
+        expect(getIconFormeSuffix("Midday")).toEqual("");
+        expect(getIconFormeSuffix("Dusk")).toEqual("-dusk");
+        expect(getIconFormeSuffix("Midnight")).toEqual("-midnight");
     });
 });
 

--- a/src/utils/formatters/matchSpeciesToTypes.ts
+++ b/src/utils/formatters/matchSpeciesToTypes.ts
@@ -131,6 +131,15 @@ export const handleSpeciesTypeEdgeCases = ({
     if (
         match({
             ...data,
+            species: ["Grimer", "Muk"],
+            forme: ["Alolan"],
+        })
+    )
+        return [Types.Poison, Types.Dark];
+
+    if (
+        match({
+            ...data,
             species: ["Meowth"],
             forme: ["Galarian"],
         })

--- a/src/utils/getters/getIconFormeSuffix.ts
+++ b/src/utils/getters/getIconFormeSuffix.ts
@@ -1,9 +1,9 @@
 import { Forme } from "utils";
 
 export const getIconFormeSuffix = (forme: keyof typeof Forme) => {
-    console.log(forme);
     if (forme == null) return "";
     if (forme === "Normal") return "";
+    if (forme === "Midday") return "";
     if (forme === "Spring") return "";
     if (
         [
@@ -15,6 +15,8 @@ export const getIconFormeSuffix = (forme: keyof typeof Forme) => {
             "Summer",
             "Winter",
             "Autumn",
+            "Dusk",
+            "Midnight",
         ].includes(forme)
     )
         return `-${forme.toLowerCase()}`;


### PR DESCRIPTION
Fixes #999
Fixes #791

## Summary
- add Lycanroc Midday/Midnight/Dusk form keys and map Dusk/Midnight to their icon suffixes while keeping Midday on the base icon
- add the missing Alolan Grimer/Muk Poison/Dark type edge case
- remove stale debug logging from icon form suffix generation
- add regressions for Alolan Muk typing and Lycanroc icon suffixes

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- Focused: `npm run test:run -- src/utils/__tests__/utils.test.ts`
- Browser smoke on Vite port 18110: seeded Dusk Lycanroc and Alolan Muk in `Compact with Icons`; confirmed rendered sources included `icons/pokemon/regular/lycanroc-dusk.png` and `icons/pokemon/regular/muk-alola.png`