### PR TITLE
Allow custom Pokemon formes

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -103,6 +103,23 @@ const getEvos = (species): string[] | undefined => {
     return EvolutionTree?.[species];
 };
 
+export const getFormeInputConfig = (species: Pokemon["species"]) => {
+    const isCustomSpecies =
+        Boolean(species) && !listOfPokemon.includes(species as Species);
+
+    if (isCustomSpecies) {
+        return {
+            type: "text" as const,
+            options: undefined,
+        };
+    }
+
+    return {
+        type: "select" as const,
+        options: ["Normal", ...getAdditionalFormes(species)],
+    };
+};
+
 export function EvolutionSelection({ currentPokemon, onEvolve }) {
     const evos = getEvos(currentPokemon?.species);
 
@@ -268,6 +285,7 @@ export class CurrentPokemonEditBase extends React.Component<
             key: `${p.nickname} (${p.species})`,
             value: p.id,
         }));
+        const formeInputConfig = getFormeInputConfig(currentPokemon.species);
 
         return (
             <div className="expanded-edit">
@@ -276,11 +294,8 @@ export class CurrentPokemonEditBase extends React.Component<
                     inputName="forme"
                     placeholder=""
                     value={currentPokemon.forme}
-                    type="select"
-                    options={[
-                        "Normal",
-                        ...getAdditionalFormes(currentPokemon.species),
-                    ]}
+                    type={formeInputConfig.type}
+                    options={formeInputConfig.options}
                     pokemon={currentPokemon}
                     key={this.state.selectedId + "forme"}
                 />

--- a/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
@@ -9,6 +9,7 @@ import {
     getContrastColor,
     matchNatureToToxtricityForme,
     Species,
+    listOfPokemon,
     normalizePokeballName,
 } from "utils";
 import { editPokemon } from "actions";
@@ -65,7 +66,7 @@ interface ChangeArgs {
     edit: PokemonEditDraft;
 }
 
-const createEdit = ({ inputName, value, pokemon, edit }: ChangeArgs) => {
+export const createEdit = ({ inputName, value, pokemon, edit }: ChangeArgs) => {
     if (inputName === "species") {
         const species = edit["species"];
         return {
@@ -88,6 +89,13 @@ const createEdit = ({ inputName, value, pokemon, edit }: ChangeArgs) => {
                     : pokemon.forme,
         };
     } else if (inputName === "forme") {
+        if (
+            pokemon?.species &&
+            !listOfPokemon.includes(pokemon.species as Species)
+        ) {
+            return edit;
+        }
+
         return {
             ...edit,
             types:

--- a/src/components/Editors/PokemonEditor/__tests__/customFormes.test.ts
+++ b/src/components/Editors/PokemonEditor/__tests__/customFormes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { Types } from "utils";
+import { Pokemon } from "models";
+import { getFormeInputConfig } from "../CurrentPokemonEdit";
+import { createEdit } from "../CurrentPokemonInput";
+
+describe("custom Pokemon formes", () => {
+    it("uses a text input for custom species formes", () => {
+        expect(getFormeInputConfig("zinunas")).toEqual({
+            type: "text",
+            options: undefined,
+        });
+    });
+
+    it("keeps canonical species on the forme select", () => {
+        expect(getFormeInputConfig("Tauros")).toMatchObject({
+            type: "select",
+            options: ["Normal", "Paldean", "Paldean-Aqua", "Paldean-Blaze"],
+        });
+    });
+
+    it("does not reset custom species types when editing a custom forme", () => {
+        const pokemon = {
+            species: "zinunas",
+            types: [Types.Shadow, "None" as Types],
+        } as Pokemon;
+
+        expect(
+            createEdit({
+                inputName: "forme",
+                value: "Speed",
+                pokemon,
+                edit: { forme: "Speed" },
+            }),
+        ).toEqual({ forme: "Speed" });
+    });
+});

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -16,7 +16,7 @@ export interface Pokemon {
     moves?: string[];
     causeOfDeath?: string;
     deathTimestamp?: string;
-    forme?: Forme;
+    forme?: Forme | string;
     item?: string;
     types?: [Types, Types];
     teraType?: Types;


### PR DESCRIPTION
Fixes #984

## Summary
- render the Forme editor as a free-text input when the selected species is custom/non-canonical
- widen the Pokemon model so saved custom form names are valid data
- preserve custom type pairs when editing custom formes
- add focused regressions for custom forme input behavior and canonical forme select behavior

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:run -- src/components/Editors/PokemonEditor/__tests__/customFormes.test.ts`
- `npm run test:run`
- `npm run build`
- Browser smoke on Vite port 18111: seeded custom Telefang-style `zinunas` with custom image/icon, `forme: Attack`, and types `["Shadow", "None"]`; opened More, confirmed Forme rendered as a text input, changed it to `Speed`, and confirmed localStorage persisted `forme: Speed` while keeping the custom type pair.