### PR TITLE
Fix FRLG sprites for Gen 2 and 3 Pokemon

### DIFF
--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => {
             const map: Record<string, number> = {
                 Ditto: 132,
                 Pikachu: 25,
+                Chikorita: 152,
+                Torchic: 255,
                 Unfezant: 521,
                 Gyarados: 130,
                 Dugtrio: 51,
@@ -258,6 +260,28 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             );
         });
 
+        it("uses Emerald sprite assets for Gen 2 and Gen 3 Pokemon in FRLG sprite mode", async () => {
+            const gen2 = await getPokemonImage({
+                species: "Chikorita",
+                name: imageGame("FireRed"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: false,
+            });
+            const gen3 = await getPokemonImage({
+                species: "Torchic",
+                name: imageGame("LeafGreen"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: true,
+            });
+
+            expect(gen2).toBe(
+                "cors(https://img.pokemondb.net/sprites/emerald/normal/chikorita.png)",
+            );
+            expect(gen3).toBe(
+                "cors(https://img.pokemondb.net/sprites/emerald/shiny/torchic.png)",
+            );
+        });
+
         it("builds Sword/Shield sprite URLs and wraps them", async () => {
             const nonShiny = await getPokemonImage({
                 species: "Pikachu",
@@ -408,4 +432,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => {
                 Ditto: 132,
                 Pikachu: 25,
                 Chikorita: 152,
+                Treecko: 252,
                 Torchic: 255,
                 Unfezant: 521,
                 Gyarados: 130,
@@ -214,6 +215,28 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             );
             expect(shiny).toBe(
                 "cors(https://serebii.net/Shiny/SV/new/025.png)",
+            );
+        });
+
+        it("uses PokemonDB Emerald sprite assets for Ruby/Sapphire/Emerald sprite mode", async () => {
+            const normal = await getPokemonImage({
+                species: "Treecko",
+                name: imageGame("Ruby"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: false,
+            });
+            const shiny = await getPokemonImage({
+                species: "Treecko",
+                name: imageGame("Emerald"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: true,
+            });
+
+            expect(normal).toBe(
+                "cors(https://img.pokemondb.net/sprites/emerald/normal/treecko.png)",
+            );
+            expect(shiny).toBe(
+                "cors(https://img.pokemondb.net/sprites/emerald/shiny/treecko.png)",
             );
         });
 

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -22,6 +22,19 @@ const handleTcgTransforms = (species?: string, gender?: GenderElementProps) => {
     return species;
 };
 
+const getPokemonDbSpriteUrl = ({
+    folder,
+    shiny,
+    species,
+}: {
+    folder: string;
+    shiny?: boolean;
+    species?: string;
+}) =>
+    `https://img.pokemondb.net/sprites/${folder}/${shiny ? "shiny" : "normal"}/${normalizeSpeciesName(
+        species as Species,
+    )}.png`;
+
 const getGameName = (name: Game) => {
     if (name === "Red" || name === "Blue") return "rb";
     if (
@@ -180,10 +193,20 @@ export async function getPokemonImage({
 
     if (
         style?.spritesMode &&
+        (name === "Ruby" || name === "Sapphire" || name === "Emerald")
+    ) {
+        return await wrapImageInCORS(
+            getPokemonDbSpriteUrl({
+                folder: "emerald",
+                shiny,
+                species,
+            }),
+        );
+    }
+
+    if (
+        style?.spritesMode &&
         (name === "Black" ||
-            name === "Emerald" ||
-            name === "Ruby" ||
-            name === "Sapphire" ||
             name === "White" ||
             name === "Black 2" ||
             name === "White 2" ||
@@ -242,19 +265,13 @@ export async function getPokemonImage({
     if (style?.spritesMode && (name === "LeafGreen" || name === "FireRed")) {
         const frlgSpriteFolder =
             (regularNumber ?? 0) > 151 ? "emerald" : "firered-leafgreen";
-        if (!shiny) {
-            const url = `https://img.pokemondb.net/sprites/${frlgSpriteFolder}/normal/${normalizeSpeciesName(
-                species as Species,
-            )}.png`;
-
-            return await wrapImageInCORS(url);
-        } else {
-            const url = `https://img.pokemondb.net/sprites/${frlgSpriteFolder}/shiny/${normalizeSpeciesName(
-                species as Species,
-            )}.png`;
-
-            return await wrapImageInCORS(url);
-        }
+        return await wrapImageInCORS(
+            getPokemonDbSpriteUrl({
+                folder: frlgSpriteFolder,
+                shiny,
+                species,
+            }),
+        );
     }
 
     if (style?.spritesMode && (name === "Sword" || name === "Shield")) {

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -240,14 +240,16 @@ export async function getPokemonImage({
     }
 
     if (style?.spritesMode && (name === "LeafGreen" || name === "FireRed")) {
+        const frlgSpriteFolder =
+            (regularNumber ?? 0) > 151 ? "emerald" : "firered-leafgreen";
         if (!shiny) {
-            const url = `https://img.pokemondb.net/sprites/firered-leafgreen/normal/${normalizeSpeciesName(
+            const url = `https://img.pokemondb.net/sprites/${frlgSpriteFolder}/normal/${normalizeSpeciesName(
                 species as Species,
             )}.png`;
 
             return await wrapImageInCORS(url);
         } else {
-            const url = `https://img.pokemondb.net/sprites/firered-leafgreen/shiny/${normalizeSpeciesName(
+            const url = `https://img.pokemondb.net/sprites/${frlgSpriteFolder}/shiny/${normalizeSpeciesName(
                 species as Species,
             )}.png`;
 


### PR DESCRIPTION
Fixes #972
Fixes #727
Fixes #684

## Summary
- Use PokemonDB Emerald sprite assets for Ruby/Sapphire/Emerald sprite mode so Hoenn runs get the cleaner static Gen III sprites.
- Use PokemonDB Emerald sprite assets for Gen 2 and Gen 3 species when FireRed/LeafGreen sprite mode is enabled.
- Keep Kanto species on the existing FireRed/LeafGreen sprite folder.
- Add regression tests for Hoenn Treecko, Chikorita, and shiny Torchic sprite URLs.

## Root cause
Serebii’s Emerald sprite path can expose early animation-frame assets for Hoenn sprites, and PokemonDB does not provide Gen 2/3 species in the `firered-leafgreen` sprite folder. PokemonDB’s `emerald` folder has the needed static normal and shiny assets.

## Validation
- URL audit: `https://www.serebii.net/emerald/pokemon/252.png` returned 200 but uses the old Serebii Emerald sprite source.
- URL audit: `https://img.pokemondb.net/sprites/emerald/normal/treecko.png`, `https://img.pokemondb.net/sprites/emerald/shiny/treecko.png`, and `https://img.pokemondb.net/sprites/emerald/normal/blastoise.png` returned 200.
- URL audit: `firered-leafgreen/normal/torchic.png` and `firered-leafgreen/normal/chikorita.png` return 404.
- URL audit: `emerald/normal/torchic.png`, `emerald/shiny/torchic.png`, `emerald/normal/chikorita.png`, and `emerald/shiny/chikorita.png` return 200 image/png.
- `npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
