### PR TITLE
Fix Champs sprite origin fallback

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -322,6 +322,9 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
                                     }
                                     key={poke.id}
                                     {...poke}
+                                    gameOfOrigin={
+                                        poke.gameOfOrigin || this.props.game.name
+                                    }
                                 />
                             );
                         if (box?.name === "Team" || box?.inheritFrom === "Team")

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -7,6 +7,10 @@ import { Editor, Box, Pokemon } from "models";
 
 type ResultBaseProps = React.ComponentProps<typeof ResultBase>;
 type PokemonSpeciesProps = { species: string };
+type ChampsPokemonProps = PokemonSpeciesProps & {
+    gameOfOrigin?: string;
+    useSprites?: boolean;
+};
 type PokemonProp = { pokemon: Pokemon };
 type ChildrenProps = { children?: React.ReactNode };
 
@@ -29,8 +33,14 @@ vi.mock("components/Pokemon/DeadPokemon/DeadPokemon", () => ({
 }));
 
 vi.mock("components/Pokemon/ChampsPokemon/ChampsPokemon", () => ({
-    ChampsPokemon: ({ species }: PokemonSpeciesProps) => (
-        <div data-testid={`champs-${species}`}>{species}</div>
+    ChampsPokemon: ({ species, gameOfOrigin, useSprites }: ChampsPokemonProps) => (
+        <div
+            data-testid={`champs-${species}`}
+            data-game-origin={gameOfOrigin}
+            data-use-sprites={String(useSprites)}
+        >
+            {species}
+        </div>
     ),
 }));
 
@@ -123,6 +133,39 @@ describe("<ResultBase />", () => {
         expect(screen.getByText("Boxed")).toBeTruthy();
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
+    });
+
+    it("falls back to the run game for Champs sprites without a Pokemon origin", () => {
+        render(
+            <ResultBase
+                pokemon={[
+                    generateEmptyPokemon([], {
+                        id: "champ-1",
+                        species: "Sceptile",
+                        status: "Champs",
+                    }),
+                ]}
+                game={{ name: "Emerald", customName: "" }}
+                trainer={{ badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    useSpritesForChampsPokemon: true,
+                }}
+                rules={[]}
+                customTypes={[]}
+            />,
+        );
+
+        const champ = screen.getByTestId("champs-Sceptile");
+        expect(champ.getAttribute("data-game-origin")).toBe("Emerald");
+        expect(champ.getAttribute("data-use-sprites")).toBe("true");
     });
 });
 


### PR DESCRIPTION
Fixes #960

## Summary
- Fall back to the current run game when rendering Champs Pokemon that do not have a per-Pokemon `gameOfOrigin`.
- Preserve explicit per-Pokemon origins for genlocke/champion color tracking.
- Add a Result regression test covering a Sceptile champion without `gameOfOrigin` in an Emerald run while Champs sprites are enabled.

## Root cause
Legacy/current-run Pokemon can lack `gameOfOrigin`. Champs sprite rendering passed that missing value through to `getPokemonImage`, which selected the generic Sun/Moon sprite path. For Sceptile that URL is `https://www.serebii.net/sm/pokemon/254.png`, which returns 404; the Emerald sprite URL returns 200.

## Validation
- URL audit: `https://www.serebii.net/sm/pokemon/254.png` returns 404.
- URL audit: `https://www.serebii.net/emerald/pokemon/254.png` returns 200 image/png.
- `npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx src/utils/getters/__tests__/getPokemonImage.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- Final post-cleanup validation: `npm run lint && npm run typecheck && npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx && npm run build`