### PR TITLE
Cover SWSH shiny sprite URLs

### DIFF
--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
             const map: Record<string, number> = {
                 Ditto: 132,
                 Pikachu: 25,
+                Shaymin: 492,
                 Unfezant: 521,
                 Gyarados: 130,
                 Dugtrio: 51,
@@ -281,6 +282,19 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             );
         });
 
+        it("uses SWSH shiny assets for shiny Pokemon in Sword sprite mode", async () => {
+            const result = await getPokemonImage({
+                species: "Shaymin",
+                name: imageGame("Sword"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: true,
+            });
+
+            expect(result).toBe(
+                "cors(https://www.serebii.net/Shiny/SWSH/492.png)",
+            );
+        });
+
         it("uses generic serebii URL builder for other games when spritesMode is true", async () => {
             const result = await getPokemonImage({
                 species: "Pikachu",
@@ -408,4 +422,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-


### PR DESCRIPTION
Fixes #937

## Summary
- Add regression coverage for shiny Pokémon in Sword sprite mode using Shaymin from the submitted save context.
- Verify Sword sprite mode returns Serebii's `Shiny/SWSH` asset URL instead of falling back to a non-shiny or generic path.

## Notes
The runtime SWSH shiny branch is already present on `master`; this PR locks that behavior to the reported scenario so it does not regress.

## Validation
- URL audit: `https://www.serebii.net/Shiny/SWSH/492.png` returns 200 image/png.
- `npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`