### PR TITLE
Fix Flabebe flower icon suffixes

### DIFF
--- a/src/utils/Forme.ts
+++ b/src/utils/Forme.ts
@@ -91,7 +91,10 @@ export enum Forme {
     Lowkey = "lowkey",
     AmpedUp = "amped",
 
+    Blue = "blue",
+    Orange = "orange",
     White = "white",
+    Yellow = "yellow",
     Black = "black",
     Zen = "zen",
 

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -28,6 +28,7 @@ import { capitalize } from "utils/formatters/capitalize";
 import { matchNatureToToxtricityForme } from "utils/matchNatureToToxtricityForme";
 import { Nature } from "utils/Nature";
 import { getAdditionalFormes } from "utils/getters/getAdditionalFormes";
+import { getIconFormeSuffix } from "utils/getters/getIconFormeSuffix";
 import { getEvolutionLine } from "utils";
 
 const objectPropertiesWhere = (
@@ -373,6 +374,15 @@ describe(getAdditionalFormes.name, () => {
             [species]: getAdditionalFormes(species),
         }));
         expect(subject).toMatchSnapshot();
+    });
+});
+
+describe(getIconFormeSuffix.name, () => {
+    it("maps Flabebe line flower colors to icon suffixes", () => {
+        expect(getIconFormeSuffix("Yellow")).toBe("-yellow");
+        expect(getIconFormeSuffix("Orange")).toBe("-orange");
+        expect(getIconFormeSuffix("Blue")).toBe("-blue");
+        expect(getIconFormeSuffix("White")).toBe("-white");
     });
 });
 


### PR DESCRIPTION
Fixes #857

## Summary
- Add Orange, Blue, and Yellow flower color forme values so icon suffix generation can resolve the existing Flabébé/Floette/Florges assets.
- Keep Red on the base asset path and keep White using the existing `white` forme value.
- Add regression coverage for flower color suffixes.

## Validation
- Existing assets verified in `src/assets/icons/pokemon/{regular,shiny}` for Flabébé, Floette, and Florges color forms.
- `npm run test:run -- src/utils/__tests__/utils.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Refs #658 (Flabébé flower-form icon portion).