### PR TITLE
Fix BDSP and Legends Arceus sprite routing

### DIFF
--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -9,10 +9,12 @@ const mocks = vi.hoisted(() => {
             const map: Record<string, number> = {
                 Ditto: 132,
                 Pikachu: 25,
+                Turtwig: 387,
                 Unfezant: 521,
                 Gyarados: 130,
                 Dugtrio: 51,
                 Indeedee: 876,
+                Kleavor: 900,
                 Basculegion: 902,
                 "Mime Jr.": 439,
                 "Mr. Mime": 122,
@@ -281,6 +283,28 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             );
         });
 
+        it("uses the SWSH sprite table for BDSP and Legends: Arceus sprite mode", async () => {
+            const bdsp = await getPokemonImage({
+                species: "Turtwig",
+                name: imageGame("Shining Pearl"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: false,
+            });
+            const legendsArceus = await getPokemonImage({
+                species: "Kleavor",
+                name: imageGame("Legends: Arceus"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: true,
+            });
+
+            expect(bdsp).toBe(
+                "cors(https://www.serebii.net/swordshield/pokemon/387.png)",
+            );
+            expect(legendsArceus).toBe(
+                "cors(https://www.serebii.net/Shiny/SWSH/900.png)",
+            );
+        });
+
         it("uses generic serebii URL builder for other games when spritesMode is true", async () => {
             const result = await getPokemonImage({
                 species: "Pikachu",
@@ -408,4 +432,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -73,7 +73,8 @@ const getGameName = (name: Game) => {
         name === "Sword" ||
         name === "Shield" ||
         name === "Brilliant Diamond" ||
-        name === "Shining Pearl"
+        name === "Shining Pearl" ||
+        name === "Legends: Arceus"
     ) {
         return "swordshield";
     }
@@ -118,7 +119,8 @@ const getGameNameSerebii = (name: Game) => {
         case "Shield":
         case "Brilliant Diamond":
         case "Shining Pearl":
-            return "swordshield";
+        case "Legends: Arceus":
+            return "SWSH";
         case "Legends: Z-A":
             return "legendsz-a";
         default:
@@ -255,7 +257,14 @@ export async function getPokemonImage({
         }
     }
 
-    if (style?.spritesMode && (name === "Sword" || name === "Shield")) {
+    if (
+        style?.spritesMode &&
+        (name === "Sword" ||
+            name === "Shield" ||
+            name === "Brilliant Diamond" ||
+            name === "Shining Pearl" ||
+            name === "Legends: Arceus")
+    ) {
         if (!shiny) {
             const url = `https://www.serebii.net/${getGameName(
                 name,


### PR DESCRIPTION
Fixes #801
Fixes #771

## Summary
- route BDSP and Legends: Arceus sprite mode through the Serebii Sword/Shield sprite table
- use the `Shiny/SWSH` directory for shiny sprites in those game modes
- add regression coverage for Shining Pearl Turtwig and shiny Legends: Arceus Kleavor sprite URLs

## Validation
- `npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- URL audit: `https://www.serebii.net/swordshield/pokemon/900.png` returned 200
- URL audit: `https://www.serebii.net/Shiny/swordshield/900.png` returned 404
- URL audit: `https://www.serebii.net/Shiny/SWSH/900.png` returned 200