### PR TITLE
Fix East Sea Shellos sprite URLs

### DIFF
--- a/src/utils/getters/__tests__/getForme.test.ts
+++ b/src/utils/getters/__tests__/getForme.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { getForme } from "../getForme";
+
+describe("@src/utils/getters/getForme.ts", () => {
+    it("uses Serebii-compatible Shellos and Gastrodon forme suffixes", () => {
+        expect(getForme("West Sea")).toBe("");
+        expect(getForme("East Sea")).toBe("-e");
+    });
+});

--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -216,6 +216,8 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
 
         it("builds DP/HGSS sprite URLs and wraps them", async () => {
+            mocks.getForme.mockReturnValueOnce("").mockReturnValueOnce("");
+
             const nonShiny = await getPokemonImage({
                 species: "Pikachu",
                 name: imageGame("Diamond"),
@@ -233,6 +235,37 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
                 "cors(https://www.serebii.net/pokearth/sprites/dp/025.png)",
             );
             expect(shiny).toBe("cors(https://www.serebii.net/Shiny/DP/025.png)");
+        });
+
+        it("includes the East Sea Shellos forme in DP/HGSS sprite URLs", async () => {
+            mocks.speciesToNumber
+                .mockReturnValueOnce(422)
+                .mockReturnValueOnce(422)
+                .mockReturnValueOnce(422)
+                .mockReturnValueOnce(422);
+            mocks.getForme.mockReturnValueOnce("-e").mockReturnValueOnce("-e");
+
+            const nonShiny = await getPokemonImage({
+                species: "Shellos",
+                name: imageGame("SoulSilver"),
+                style: imageStyle({ spritesMode: true }),
+                forme: imageForme("East Sea"),
+                shiny: false,
+            });
+            const shiny = await getPokemonImage({
+                species: "Shellos",
+                name: imageGame("Pearl"),
+                style: imageStyle({ spritesMode: true }),
+                forme: imageForme("East Sea"),
+                shiny: true,
+            });
+
+            expect(nonShiny).toBe(
+                "cors(https://www.serebii.net/pokearth/sprites/dp/422-e.png)",
+            );
+            expect(shiny).toBe(
+                "cors(https://www.serebii.net/Shiny/DP/422-e.png)",
+            );
         });
 
         it("builds FRLG sprite URLs via pokemondb and wraps them", async () => {
@@ -408,4 +441,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getForme.ts
+++ b/src/utils/getters/getForme.ts
@@ -14,7 +14,7 @@ export const getForme = (forme) => {
     if (forme === "Kabuki") return "-k";
     if (forme === "Pharaoh") return "-p";
     if (forme === "Mega") return "-m";
-    if (forme === "East Sea") return "e";
+    if (forme === "East Sea") return "-e";
     if (forme === "Eternal Flower") return "-eternal";
     return "";
 };

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -229,11 +229,11 @@ export async function getPokemonImage({
 
     if (style?.spritesMode && (name === "Diamond" || name === "Pearl" || name === "Platinum" || name === "HeartGold" || name === "SoulSilver")) {
         if (!shiny) {
-            const url = `https://www.serebii.net/pokearth/sprites/dp/${leadingZerosNumber}.png`;
+            const url = `https://www.serebii.net/pokearth/sprites/dp/${leadingZerosNumber}${getForme(forme)}.png`;
 
             return await wrapImageInCORS(url);
         } else {
-            const url = `https://www.serebii.net/Shiny/DP/${leadingZerosNumber}.png`;
+            const url = `https://www.serebii.net/Shiny/DP/${leadingZerosNumber}${getForme(forme)}.png`;
 
             return await wrapImageInCORS(url);
         }


### PR DESCRIPTION
Fixes #799

## Summary
- normalize East Sea form suffixes to Serebii’s `-e` filename convention
- include form suffixes in Diamond/Pearl/Platinum/HeartGold/SoulSilver sprite-mode URLs
- add regression coverage for East Sea Shellos in SoulSilver and Pearl sprite mode

## Validation
- `npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts src/utils/getters/__tests__/getForme.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- URL audit: `https://www.serebii.net/pokearth/sprites/dp/422.png` returned 200
- URL audit: `https://www.serebii.net/pokearth/sprites/dp/422e.png` returned 404
- URL audit: `https://www.serebii.net/pokearth/sprites/dp/422-e.png` returned 200
- URL audit: `https://www.serebii.net/Shiny/DP/422-e.png` returned 200