### PR TITLE
Add Mahogany Town to Johto locations

### DIFF
--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -307,6 +307,7 @@ describe(getEncounterMap.name, () => {
         const JohtoGen4 = getEncounterMap("HeartGold");
         expect(KantoGen3.length).toBeGreaterThan(KantoGen1.length);
         expect(JohtoGen4).toContain("Route 29");
+        expect(JohtoGen4).toContain("Mahogany Town");
     });
 });
 

--- a/src/utils/data/listOfLocations.ts
+++ b/src/utils/data/listOfLocations.ts
@@ -116,6 +116,7 @@ export const locations = {
         "Ice Path",
         "Ilex Forest",
         "Lake of Rage",
+        "Mahogany Town",
         "Mt. Mortar",
         "Mt. Silver",
         "National Park",


### PR DESCRIPTION
Fixes #605
Fixes #415

## Summary
- add Mahogany Town to the Johto encounter/location list
- cover HeartGold/SoulSilver encounter maps so Mahogany Town stays available for egg hatch locations and ROM hacks

## Validation
- `npm run test:run -- src/utils/__tests__/utils.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`