### PR TITLE
Keep generated Nuzlocke title on one line

### DIFF
--- a/src/components/Features/Result/Result.css
+++ b/src/components/Features/Result/Result.css
@@ -77,6 +77,7 @@
     display: inline-flex;
     font-size: 1.5rem;
     font-weight: light;
+    white-space: nowrap;
 }
 .badge-wrapper {
     width: 216px;
@@ -462,4 +463,3 @@
 .pokemon-checkpoint.obtained {
     display: flex;
 }
-


### PR DESCRIPTION
Fixes #720.

## Summary
- Prevents the generated result title from wrapping between the game name and `Nuzlocke`.
- Keeps short titles like `Y Nuzlocke` on one line in the downloaded result image.

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build