### PR TITLE
Use female Indeedee Sword/Shield sprites

### DIFF
--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -281,6 +281,30 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             );
         });
 
+        it("builds female Indeedee Sword/Shield sprite URLs", async () => {
+            const nonShiny = await getPokemonImage({
+                species: "Indeedee",
+                gender: imageGender("Female"),
+                name: imageGame("Sword"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: false,
+            });
+            const shiny = await getPokemonImage({
+                species: "Indeedee",
+                gender: imageGender("f"),
+                name: imageGame("Shield"),
+                style: imageStyle({ spritesMode: true }),
+                shiny: true,
+            });
+
+            expect(nonShiny).toBe(
+                "cors(https://www.serebii.net/swordshield/pokemon/876-f.png)",
+            );
+            expect(shiny).toBe(
+                "cors(https://www.serebii.net/Shiny/SWSH/876-f.png)",
+            );
+        });
+
         it("uses generic serebii URL builder for other games when spritesMode is true", async () => {
             const result = await getPokemonImage({
                 species: "Pikachu",
@@ -408,4 +432,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -22,6 +22,20 @@ const handleTcgTransforms = (species?: string, gender?: GenderElementProps) => {
     return species;
 };
 
+const isFemaleGender = (gender?: GenderElementProps) =>
+    gender === "Female" || gender === "f";
+
+const getSwordShieldSpriteSuffix = (
+    forme?: Pokemon["forme"] | keyof typeof Forme,
+    species?: string,
+    gender?: GenderElementProps,
+) => {
+    const formeSuffix = getForme(forme);
+    if (formeSuffix) return formeSuffix;
+    if (species === "Indeedee" && isFemaleGender(gender)) return "-f";
+    return "";
+};
+
 const getGameName = (name: Game) => {
     if (name === "Red" || name === "Blue") return "rb";
     if (
@@ -256,14 +270,15 @@ export async function getPokemonImage({
     }
 
     if (style?.spritesMode && (name === "Sword" || name === "Shield")) {
+        const spriteSuffix = getSwordShieldSpriteSuffix(forme, species, gender);
         if (!shiny) {
             const url = `https://www.serebii.net/${getGameName(
                 name,
-            )}/pokemon/${leadingZerosNumber}${getForme(forme)}.png`;
+            )}/pokemon/${leadingZerosNumber}${spriteSuffix}.png`;
 
             return await wrapImageInCORS(url);
         }
-        const url = `https://www.serebii.net/Shiny/SWSH/${leadingZerosNumber}.png`;
+        const url = `https://www.serebii.net/Shiny/SWSH/${leadingZerosNumber}${spriteSuffix}.png`;
         return await wrapImageInCORS(url);
     }
 


### PR DESCRIPTION
Fixes #562.

## Summary
- Adds a Sword/Shield sprite suffix helper for gender-specific sprite paths.
- Routes female Indeedee to Serebii's `876-f.png` sprite in normal and shiny sprites mode.
- Keeps existing forme suffix handling ahead of the gender fallback.

## Validation
- npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- URL audits:
  - https://www.serebii.net/swordshield/pokemon/876.png -> 200 image/png
  - https://www.serebii.net/swordshield/pokemon/876-f.png -> 200 image/png
  - https://www.serebii.net/Shiny/SWSH/876.png -> 200 image/png
  - https://www.serebii.net/Shiny/SWSH/876-f.png -> 200 image/png