### PR TITLE
Use available TCG assets for female Frillish and Jellicent

### DIFF
--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -58,7 +58,7 @@ vi.mock("utils", () => ({
         Alolan: "alolan",
         Galarian: "galarian",
     },
-    significantGenderDifferenceList: ["Pikachu"],
+    significantGenderDifferenceList: ["Frillish", "Jellicent", "Unfezant"],
     speciesToNumber: mocks.speciesToNumber,
     getForme: mocks.getForme,
     addForme: mocks.addForme,
@@ -335,14 +335,30 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             expect(result).toBe("url(img/shuffle/mime-jr.png)");
         });
 
-        it("returns tcg assets, adding -f for significant gender differences", async () => {
+        it("returns tcg assets, adding -f when a female asset exists", async () => {
             const result = await getPokemonImage({
-                species: "Pikachu",
+                species: "Unfezant",
                 gender: imageGender("Female"),
                 style: imageStyle({ teamImages: "tcg" }),
             });
 
-            expect(result).toBe("url(img/tcg/pikachu-f.jpg)");
+            expect(result).toBe("url(img/tcg/unfezant-f.jpg)");
+        });
+
+        it("returns base tcg assets for female Frillish and Jellicent", async () => {
+            const frillish = await getPokemonImage({
+                species: "Frillish",
+                gender: imageGender("Female"),
+                style: imageStyle({ teamImages: "tcg" }),
+            });
+            const jellicent = await getPokemonImage({
+                species: "Jellicent",
+                gender: imageGender("Female"),
+                style: imageStyle({ teamImages: "tcg" }),
+            });
+
+            expect(frillish).toBe("url(img/tcg/frillish.jpg)");
+            expect(jellicent).toBe("url(img/tcg/jellicent.jpg)");
         });
     });
 
@@ -408,4 +424,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -14,9 +14,15 @@ import { State } from "state";
 import { GenderElementProps } from "components";
 import { getImages } from "components/Common/Shared/ImagesDrawer";
 
+const speciesWithFemaleTcgAsset = ["Meowstic", "Pyroar", "Unfezant"];
+
 const handleTcgTransforms = (species?: string, gender?: GenderElementProps) => {
     if (gender === "Female") {
-        if (species && significantGenderDifferenceList.includes(species))
+        if (
+            species &&
+            significantGenderDifferenceList.includes(species) &&
+            speciesWithFemaleTcgAsset.includes(species)
+        )
             return `${species}-f`;
     }
     return species;


### PR DESCRIPTION
Fixes #484.

## Summary
- Keeps the TCG `-f` suffix only for species that have a matching female TCG asset in the repo.
- Falls female Frillish and Jellicent back to the existing base TCG images so they render instead of pointing at missing `-f` files.
- Adds regression coverage for female Frillish, female Jellicent, and a species that still has a female TCG asset.

## Validation
- npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- Asset audit: `frillish.jpg`, `jellicent.jpg`, and `unfezant-f.jpg` exist; `frillish-f.jpg` and `jellicent-f.jpg` are absent as expected.