### PR TITLE
Cover Verity Lakefront in Sinnoh encounters

### DIFF
--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -305,8 +305,10 @@ describe(getEncounterMap.name, () => {
         const KantoGen1 = getEncounterMap("Red");
         const KantoGen3 = getEncounterMap("FireRed");
         const JohtoGen4 = getEncounterMap("HeartGold");
+        const SinnohGen4 = getEncounterMap("Platinum");
         expect(KantoGen3.length).toBeGreaterThan(KantoGen1.length);
         expect(JohtoGen4).toContain("Route 29");
+        expect(SinnohGen4).toContain("Verity Lakefront");
     });
 });
 


### PR DESCRIPTION
Fixes #467.

## Summary
- Adds regression coverage that Platinum/Sinnoh encounter maps include `Verity Lakefront`.
- Keeps the existing encounter location data intact while preventing this reported location from being dropped again.

## Validation
- npm run test:run -- src/utils/__tests__/utils.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check