### PR TITLE
Hide Tohjo Falls from Kanto encounter maps

### DIFF
--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -307,6 +307,9 @@ describe(getEncounterMap.name, () => {
         const JohtoGen4 = getEncounterMap("HeartGold");
         expect(KantoGen3.length).toBeGreaterThan(KantoGen1.length);
         expect(JohtoGen4).toContain("Route 29");
+        expect(KantoGen1).not.toContain("Tohjo Falls");
+        expect(KantoGen3).not.toContain("Tohjo Falls");
+        expect(JohtoGen4).toContain("Tohjo Falls");
     });
 });
 

--- a/src/utils/getters/getEncounterMap.ts
+++ b/src/utils/getters/getEncounterMap.ts
@@ -2,16 +2,19 @@ import { Game, locations } from "utils";
 import { getGameRegion, Region } from "./getGameRegion";
 import { Generation, getGameGeneration } from "./getGameGeneration";
 
+const getKantoGameLocations = () =>
+    locations.Kanto.filter((location) => location !== "Tohjo Falls");
+
 export function getEncounterMap(game: Game) {
     const region = getGameRegion(game);
     const generation = getGameGeneration(game);
 
     if (region === Region.Kanto && generation === Generation.Gen1) {
-        return locations.Kanto;
+        return getKantoGameLocations();
     }
 
     if (region === Region.Kanto && generation === Generation.Gen3) {
-        return [...locations.Kanto, ...locations.Sevii];
+        return [...getKantoGameLocations(), ...locations.Sevii];
     }
 
     if (region === Region.Johto) {


### PR DESCRIPTION
Fixes #373.

## Summary
- Filters `Tohjo Falls` out of Kanto-game encounter maps for Gen 1 and Gen 3 games.
- Preserves `Tohjo Falls` for Johto encounter maps, which still combine Johto and Kanto locations.
- Adds regression coverage for Red, FireRed, and HeartGold encounter maps.

## Validation
- npm run test:run -- src/utils/__tests__/utils.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check