### PR TITLE
Cover Minimal Champs Layout toggle

### DIFF
--- a/src/components/Editors/StyleEditor/__tests__/StyleEditor.test.tsx
+++ b/src/components/Editors/StyleEditor/__tests__/StyleEditor.test.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "utils/testUtils";
+import { vi } from "vitest";
+
+import { StyleEditorBase, StyleEditorProps } from "../StyleEditor";
+import { styleDefaults } from "utils";
+
+const createProps = (): StyleEditorProps => ({
+    style: {
+        ...styleDefaults,
+        minimalChampsLayout: true,
+    },
+    editStyle: vi.fn(),
+    game: { name: "Gold", customName: "" },
+});
+
+describe("<StyleEditor />", () => {
+    it("renders a separate Minimal Champs Layout toggle", () => {
+        const props = createProps();
+
+        render(<StyleEditorBase {...props} />);
+
+        const checkbox = screen.getByLabelText("Minimal Champs Layout");
+        expect(checkbox).toBeDefined();
+        expect((checkbox as HTMLInputElement).checked).toBe(true);
+    });
+
+    it("updates minimalChampsLayout when the champs toggle changes", () => {
+        const props = createProps();
+
+        render(<StyleEditorBase {...props} />);
+
+        fireEvent.click(screen.getByLabelText("Minimal Champs Layout"));
+
+        expect(props.editStyle).toHaveBeenCalledWith({
+            minimalChampsLayout: false,
+        });
+    });
+});


### PR DESCRIPTION
Fixes #669.
Fixes #689.

## Summary
- Adds StyleEditor regression coverage for the existing `Minimal Champs Layout` control.
- Verifies the champs layout toggle is rendered separately and dispatches `minimalChampsLayout` changes.

## Validation
- npm run test:run -- src/components/Editors/StyleEditor/__tests__/StyleEditor.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check