### PR TITLE
Cover save parser Buffer regression

### DIFF
--- a/src/parsers/__tests__/buffer-polyfill.test.ts
+++ b/src/parsers/__tests__/buffer-polyfill.test.ts
@@ -18,8 +18,11 @@ afterEach(() => {
 });
 
 describe("save parsers without a global Buffer", () => {
-    it("parses Gen 1 browser uploads without reading global Buffer", async () => {
-        const savePath = join(__dirname, "../red.sav");
+    it.each([
+        ["Red", "red.sav"],
+        ["Blue", "blue.sav"],
+    ])("parses Gen 1 %s browser uploads without reading global Buffer", async (_game, fixture) => {
+        const savePath = join(__dirname, `../${fixture}`);
         const saveData = Buffer.from(readFileSync(savePath));
         Reflect.deleteProperty(globalWithBuffer, "Buffer");
         vi.resetModules();
@@ -28,6 +31,22 @@ describe("save parsers without a global Buffer", () => {
         const result = await parseGen1Save(saveData, {
             boxMappings: generateDefaultBoxMappings("RBY"),
             selectedGame: "RBY",
+        });
+
+        expect(result.trainer).toBeDefined();
+        expect(result.pokemon.length).toBeGreaterThan(0);
+    });
+
+    it("parses Gen 3 browser uploads without reading global Buffer", async () => {
+        const savePath = join(__dirname, "../emerald.sav");
+        const saveData = Buffer.from(readFileSync(savePath));
+        Reflect.deleteProperty(globalWithBuffer, "Buffer");
+        vi.resetModules();
+
+        const { parseGen3Save } = await import("../gen3");
+        const result = await parseGen3Save(saveData, {
+            boxMappings: generateDefaultBoxMappings("Emerald"),
+            selectedGame: "Emerald",
         });
 
         expect(result.trainer).toBeDefined();

--- a/src/parsers/__tests__/buffer-polyfill.test.ts
+++ b/src/parsers/__tests__/buffer-polyfill.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "node:path";
+import { Buffer } from "buffer";
+import { generateDefaultBoxMappings } from "reducers/saveUploadSettings";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+type BufferGlobal = typeof globalThis & { Buffer?: typeof Buffer };
+
+const globalWithBuffer = globalThis as BufferGlobal;
+const originalGlobalBuffer = globalWithBuffer.Buffer;
+
+afterEach(() => {
+    globalWithBuffer.Buffer = originalGlobalBuffer;
+});
+
+describe("save parsers without a global Buffer", () => {
+    it("parses Gen 1 browser uploads without reading global Buffer", async () => {
+        const savePath = join(__dirname, "../red.sav");
+        const saveData = Buffer.from(readFileSync(savePath));
+        Reflect.deleteProperty(globalWithBuffer, "Buffer");
+        vi.resetModules();
+
+        const { parseGen1Save } = await import("../gen1");
+        const result = await parseGen1Save(saveData, {
+            boxMappings: generateDefaultBoxMappings("RBY"),
+            selectedGame: "RBY",
+        });
+
+        expect(result.trainer).toBeDefined();
+        expect(result.pokemon.length).toBeGreaterThan(0);
+    });
+
+    it("parses Gen 2 browser uploads without reading global Buffer", async () => {
+        const savePath = join(__dirname, "../crystal.sav");
+        const saveData = Buffer.from(readFileSync(savePath));
+        Reflect.deleteProperty(globalWithBuffer, "Buffer");
+        vi.resetModules();
+
+        const { parseGen2Save } = await import("../gen2");
+        const result = await parseGen2Save(saveData, {
+            boxMappings: generateDefaultBoxMappings("Crystal"),
+            selectedGame: "Crystal",
+            isCrystal: true,
+        });
+
+        expect(result.trainer).toBeDefined();
+        expect(result.pokemon.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Fixes #525.
Fixes #457.
Fixes #468.
Fixes #534.

## Summary
- Adds browser-mode regression coverage for the old `ReferenceError: Buffer is not defined` save-upload failure.
- Verifies Gen 1, Gen 2, and Gen 3 parser entrypoints parse Red, Blue, Crystal, and Emerald fixture saves after `globalThis.Buffer` is removed.

## Validation
- npm run test:run -- src/parsers/__tests__/buffer-polyfill.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
