### PR TITLE
Import PKHeX JSON exports

### DIFF
--- a/src/components/Editors/DataEditor/DataEditor.tsx
+++ b/src/components/Editors/DataEditor/DataEditor.tsx
@@ -43,6 +43,7 @@ import SaveFileWorker from "parsers/worker?worker";
 import { cx } from "emotion";
 import { StatusDropZone } from "./StatusDropZone";
 import { serializeNuzlockeJson } from "utils/nuzlockeJson";
+import { normalizeImportedJsonData } from "utils/pkhexJsonImport";
 
 export interface DataEditorProps {
     state: State;
@@ -301,7 +302,24 @@ export class DataEditorBase extends React.Component<
             customMoveMap: [],
         };
         const override = this.state.overrideImport;
-        const data = handleExceptions(JSON.parse(this.state.data));
+        const data = normalizeImportedJsonData(
+            handleExceptions(JSON.parse(this.state.data)),
+        );
+        if (Array.isArray(data)) {
+            showToast({
+                message: "Unsupported JSON import format",
+                intent: Intent.DANGER,
+            });
+            return;
+        }
+        if (!data || typeof data !== "object") {
+            showToast({
+                message: "Unsupported JSON import format",
+                intent: Intent.DANGER,
+            });
+            return;
+        }
+        const importData = data as Partial<State>;
         const nuz = this.props.state;
         // @NOTE this prevents previously undefined states from blowing up the app
         const safeguards = {
@@ -311,17 +329,18 @@ export class DataEditorBase extends React.Component<
             excludedAreas: [],
             customAreas: [],
         };
-        if (!Array.isArray(data.customMoveMap)) {
+        if (!Array.isArray(importData.customMoveMap)) {
             noop();
         } else {
-            cmm = { customMoveMap: data.customMoveMap };
+            cmm = { customMoveMap: importData.customMoveMap };
         }
-        this.props.replaceState({
+        const nextData = {
             ...safeguards,
-            ...(override ? data : nuz),
+            ...(override ? importData : nuz),
             ...cmm,
-        });
-        this.props.newNuzlocke(this.state.data, { isCopy: false });
+        };
+        this.props.replaceState(nextData);
+        this.props.newNuzlocke(JSON.stringify(nextData), { isCopy: false });
         this.writeAllData();
         this.setState({ isOpen: false });
     };
@@ -346,7 +365,9 @@ export class DataEditorBase extends React.Component<
     private renderTeam(data: string) {
         let d: { pokemon?: Pokemon[] };
         try {
-            d = handleExceptions(JSON.parse(data)) as { pokemon?: Pokemon[] };
+            d = normalizeImportedJsonData(
+                handleExceptions(JSON.parse(data)),
+            ) as { pokemon?: Pokemon[] };
         } catch {
             d = {};
         }

--- a/src/utils/__tests__/pkhexJsonImport.test.ts
+++ b/src/utils/__tests__/pkhexJsonImport.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+    normalizeImportedJsonData,
+    parsePkhexJsonPokemon,
+} from "../pkhexJsonImport";
+
+describe("PKHeX JSON imports", () => {
+    const pkhexRows = [
+        {
+            Species: ":--:",
+            Nickname: ":--:",
+            Position: ":--:",
+        },
+        {
+            Position:
+                "4997 - Pokemon - Platinum Version (USA) (Rev 1).dsv @ [01] (BOX 1)-01: 156 - bun - DB0A30285DB3.pk4",
+            Nickname: "bun",
+            Species: "Quilava",
+            Nature: "Calm",
+            Gender: "M",
+            Ability: "Blaze",
+            Move1: "Lava Plume",
+            Move2: "Defense Curl",
+            Move3: "Reversal",
+            Move4: "Ember",
+            HeldItem: "Charcoal",
+            MetLoc: "Floaroma Town",
+            Ball: "Poké Ball",
+            Version: "Platinum",
+            Level: "32",
+            MetLevel: "15",
+            IsEgg: "False",
+            IsShiny: "False",
+        },
+        {
+            Position:
+                "4997 - Pokemon - Platinum Version (USA) (Rev 1).dsv @ Party: 0: 400 ★ - simple???? - 2C8ABB08F7BA.pk4",
+            Nickname: "simple????",
+            Species: "Bibarel",
+            Nature: "Careful",
+            Gender: "M",
+            Ability: "Simple",
+            Move1: "Crunch",
+            Move2: "Swords Dance",
+            Move3: "Yawn",
+            Move4: "Hyper Fang",
+            HeldItem: "(None)",
+            MetLoc: "Route 208",
+            Ball: "Poké Ball",
+            Version: "Platinum",
+            Level: "31",
+            MetLevel: "24",
+            IsEgg: "False",
+            IsShiny: "True",
+        },
+    ];
+
+    it("converts PKHeX JSON rows into nuzlocke Pokemon", () => {
+        const pokemon = parsePkhexJsonPokemon(pkhexRows);
+
+        expect(pokemon).toHaveLength(2);
+        expect(pokemon?.[0]).toMatchObject({
+            species: "Quilava",
+            nickname: "bun",
+            status: "Boxed",
+            level: 32,
+            met: "Floaroma Town",
+            metLevel: 15,
+            nature: "Calm",
+            ability: "Blaze",
+            item: "Charcoal",
+            pokeball: "Poké Ball",
+            gameOfOrigin: "Platinum",
+            gender: "Male",
+            shiny: false,
+            egg: false,
+            moves: ["Lava Plume", "Defense Curl", "Reversal", "Ember"],
+        });
+        expect(pokemon?.[1]).toMatchObject({
+            species: "Bibarel",
+            nickname: "simple????",
+            status: "Team",
+            shiny: true,
+            item: undefined,
+        });
+    });
+
+    it("normalizes PKHeX arrays into importable state data", () => {
+        expect(normalizeImportedJsonData(pkhexRows)).toMatchObject({
+            pokemon: [
+                { species: "Quilava", status: "Boxed" },
+                { species: "Bibarel", status: "Team" },
+            ],
+        });
+    });
+
+    it("leaves unsupported JSON arrays unchanged", () => {
+        const unsupported = [{ nope: true }];
+
+        expect(normalizeImportedJsonData(unsupported)).toBe(unsupported);
+    });
+});

--- a/src/utils/pkhexJsonImport.ts
+++ b/src/utils/pkhexJsonImport.ts
@@ -1,0 +1,109 @@
+import { v4 as uuid } from "uuid";
+import { Pokemon } from "models";
+import { GenderElementProps } from "components/Common/Shared";
+import { Types } from "./Types";
+import { Game as GameName } from "./data/listOfGames";
+import { Species } from "./data/listOfPokemon";
+import { matchSpeciesToTypes } from "./formatters/matchSpeciesToTypes";
+import { getGameGeneration } from "./getters/getGameGeneration";
+
+type PkhexJsonRow = Record<string, unknown>;
+
+const PLACEHOLDERS = new Set([":--:", "(None)", ""]);
+
+const cleanString = (value: unknown) => {
+    if (typeof value !== "string") return undefined;
+    const trimmed = value.trim();
+    return PLACEHOLDERS.has(trimmed) ? undefined : trimmed;
+};
+
+const parseNumber = (value: unknown) => {
+    const cleaned = cleanString(value);
+    if (!cleaned) return undefined;
+
+    const parsed = Number.parseInt(cleaned, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const parseBoolean = (value: unknown) => {
+    const cleaned = cleanString(value)?.toLowerCase();
+    if (cleaned === "true") return true;
+    if (cleaned === "false") return false;
+    return undefined;
+};
+
+const parseGender = (value: unknown): GenderElementProps => {
+    const cleaned = cleanString(value);
+    if (cleaned === "M") return "Male";
+    if (cleaned === "F") return "Female";
+    if (cleaned === "-") return "genderless";
+    return undefined;
+};
+
+const parseMoves = (row: PkhexJsonRow) =>
+    ["Move1", "Move2", "Move3", "Move4"]
+        .map((key) => cleanString(row[key]))
+        .filter((move): move is string => Boolean(move));
+
+const parseStatus = (row: PkhexJsonRow) => {
+    const position = cleanString(row.Position);
+    return position?.includes(" @ Party:") ? "Team" : "Boxed";
+};
+
+const isPkhexJsonRow = (row: unknown): row is PkhexJsonRow => {
+    if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+
+    const species = cleanString((row as PkhexJsonRow).Species);
+    return Boolean(species);
+};
+
+const parsePkhexPokemon = (row: PkhexJsonRow, position: number): Pokemon | null => {
+    const species = cleanString(row.Species);
+    if (!species) return null;
+
+    const gameOfOrigin = cleanString(row.Version) as GameName | undefined;
+    const generation = gameOfOrigin ? getGameGeneration(gameOfOrigin) : undefined;
+    const types = matchSpeciesToTypes(species as Species, undefined, generation);
+    const moves = parseMoves(row);
+
+    return {
+        id: uuid(),
+        position,
+        species,
+        nickname: cleanString(row.Nickname),
+        status: parseStatus(row),
+        gender: parseGender(row.Gender),
+        level: parseNumber(row.Level),
+        met: cleanString(row.MetLoc),
+        metLevel: parseNumber(row.MetLevel),
+        nature: cleanString(row.Nature),
+        ability: cleanString(row.Ability),
+        item: cleanString(row.HeldItem),
+        pokeball: cleanString(row.Ball),
+        gameOfOrigin,
+        shiny: parseBoolean(row.IsShiny),
+        egg: parseBoolean(row.IsEgg) ?? false,
+        types: types ?? [Types.Normal, Types.Normal],
+        moves,
+    };
+};
+
+export const parsePkhexJsonPokemon = (data: unknown): Pokemon[] | undefined => {
+    if (!Array.isArray(data)) return undefined;
+
+    const pokemon = data
+        .filter(isPkhexJsonRow)
+        .map((row, position) => parsePkhexPokemon(row, position))
+        .filter((pokemon): pokemon is Pokemon => Boolean(pokemon));
+
+    return pokemon.length ? pokemon : undefined;
+};
+
+export const normalizeImportedJsonData = (data: unknown) => {
+    const pkhexPokemon = parsePkhexJsonPokemon(data);
+    if (pkhexPokemon) {
+        return { pokemon: pkhexPokemon };
+    }
+
+    return data;
+};


### PR DESCRIPTION
Fixes #825.

## Summary
- Adds a conservative PKHeX JSON-array importer for DataEditor imports.
- Converts recognized PKHeX Pokemon rows into nuzlocke Pokemon entries and ignores placeholder rows.
- Shows an unsupported-format toast for JSON arrays that still cannot be imported, instead of silently applying array data.

## Validation
- npm run test:run -- src/utils/__tests__/pkhexJsonImport.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check