### PR TITLE
Fix average level stats

### DIFF
--- a/src/components/Features/Result/Stats.tsx
+++ b/src/components/Features/Result/Stats.tsx
@@ -127,30 +127,25 @@ export class StatsBase extends React.Component<
     }
 
     private getAverageLevel() {
-        const pokes = this.props.pokemon.filter((p) => !p.hidden);
-        return (
-            pokes.reduce((prev, poke, arr) => {
-                if (Number.isNaN(poke.level) || !poke.level) {
-                    return prev;
-                }
-                return prev + Number.parseInt(poke.level as unknown as string);
-            }, 0) / pokes.length
+        return this.getAverageLevelForPokemon(
+            this.props.pokemon.filter((p) => !p.hidden),
         );
     }
 
     private getAverageLevelByStatus(status: string) {
-        const pokes = this.props.pokemon.filter(
-            (p) => !p.hidden && p.status === status,
+        return this.getAverageLevelForPokemon(
+            this.props.pokemon.filter((p) => !p.hidden && p.status === status),
         );
-        if (!pokes.length) return 0;
-        return (
-            pokes.reduce((prev, poke, arr) => {
-                if (Number.isNaN(poke.level) || !poke.level) {
-                    return prev;
-                }
-                return prev + Number.parseInt(poke.level as unknown as string);
-            }, 0) / pokes.length
-        );
+    }
+
+    private getAverageLevelForPokemon(pokemon: State["pokemon"]) {
+        const levels = pokemon
+            .map((poke) => Number.parseInt(String(poke.level), 10))
+            .filter((level) => Number.isFinite(level));
+
+        if (!levels.length) return 0;
+
+        return levels.reduce((total, level) => total + level, 0) / levels.length;
     }
 
     private getShinies() {
@@ -181,12 +176,12 @@ export class StatsBase extends React.Component<
                 Average Level:{" "}
                 {this.props.box.map((b, idx, arr) => {
                     return (
-                        <>
+                        <React.Fragment key={b.id}>
                             {" "}
                             {b.name} (
                             {this.getAverageLevelByStatus(b.name)?.toFixed(0)})
                             {idx < arr.length - 1 ? "," : ""}
-                        </>
+                        </React.Fragment>
                     );
                 })}
             </div>

--- a/src/components/Features/Result/__tests__/Stats.test.tsx
+++ b/src/components/Features/Result/__tests__/Stats.test.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import { render, screen } from "utils/testUtils";
+import { Pokemon } from "models";
+import { Types } from "utils";
+import { styleDefaults } from "utils/styleDefaults";
+import { StatsBase } from "../Stats";
+
+const pokemon = (overrides: Partial<Pokemon>): Pokemon => ({
+    id: "pokemon-id",
+    species: "Bulbasaur",
+    types: [Types.Grass, Types.Poison],
+    egg: false,
+    ...overrides,
+});
+
+describe("StatsBase", () => {
+    it("averages only visible pokemon with valid levels", () => {
+        render(
+            <StatsBase
+                pokemon={[
+                    pokemon({
+                        id: "boxed-47",
+                        status: "Boxed",
+                        level: "47" as unknown as number,
+                    }),
+                    pokemon({ id: "blank", status: "Boxed" }),
+                    pokemon({
+                        id: "invalid",
+                        status: "Boxed",
+                        level: "not a level" as unknown as number,
+                    }),
+                    pokemon({ id: "dead-53", status: "Dead", level: 53 }),
+                    pokemon({
+                        id: "hidden-100",
+                        status: "Dead",
+                        level: 100,
+                        hidden: true,
+                    }),
+                ]}
+                style={{
+                    ...styleDefaults,
+                    statsOptions: {
+                        ...styleDefaults.statsOptions,
+                        averageLevel: true,
+                    },
+                }}
+                box={[]}
+            />,
+        );
+
+        expect(screen.getByText("Average Level: 50")).toBeTruthy();
+    });
+
+    it("averages custom status buckets using only valid levels", () => {
+        render(
+            <StatsBase
+                pokemon={[
+                    pokemon({
+                        id: "champion-60",
+                        status: "Champions",
+                        level: "60" as unknown as number,
+                    }),
+                    pokemon({ id: "champion-empty", status: "Champions" }),
+                    pokemon({ id: "champion-62", status: "Champions", level: 62 }),
+                    pokemon({ id: "mvp-100", status: "MVP", level: 100 }),
+                    pokemon({
+                        id: "mvp-hidden",
+                        status: "MVP",
+                        level: 2,
+                        hidden: true,
+                    }),
+                ]}
+                style={{
+                    ...styleDefaults,
+                    statsOptions: {
+                        ...styleDefaults.statsOptions,
+                        averageLevelDetailed: true,
+                    },
+                }}
+                box={[
+                    { id: 6, name: "Champions", position: 4 },
+                    { id: 8, name: "MVP", position: 6 },
+                ]}
+            />,
+        );
+
+        expect(screen.getByText(/Champions \(61\)/)).toBeTruthy();
+        expect(screen.getByText(/MVP \(100\)/)).toBeTruthy();
+    });
+});


### PR DESCRIPTION
Fixes #521.

## Summary
- Calculates average level from visible Pokemon with parseable levels only.
- Applies the same valid-level averaging to detailed/custom status buckets.
- Adds Stats regression coverage for imported string levels, blank rows, hidden rows, and custom statuses from the issue shape.
- Adds keys to detailed average-level status fragments.

## Validation
- npm run test:run -- src/components/Features/Result/__tests__/Stats.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check