### PR TITLE
Fix custom stats editor inputs

### DIFF
--- a/src/components/Editors/StatsEditor/StatsEditor.tsx
+++ b/src/components/Editors/StatsEditor/StatsEditor.tsx
@@ -60,6 +60,7 @@ export class StatsEditorBase extends React.Component<StatsEditorProps> {
         const { style, editStyle } = this.props;
         const { addStat, deleteStat } = this.props;
         const stats = style?.statsOptions;
+        const customStats = [...(this.props.stats ?? [])].sort(sortById);
 
         return (
             <BaseEditor icon="chart" name="Stats">
@@ -126,7 +127,7 @@ export class StatsEditorBase extends React.Component<StatsEditorProps> {
                             />
                         </li>
 
-                        {this.props.stats?.sort(sortById).map((stat) => (
+                        {customStats.map((stat) => (
                             <li
                                 style={{
                                     display: "flex",
@@ -140,16 +141,18 @@ export class StatsEditorBase extends React.Component<StatsEditorProps> {
                                     style={{ margin: "4px" }}
                                     className={Classes.INPUT}
                                     type="text"
+                                    aria-label="custom stat label"
                                     placeholder="custom label"
-                                    value={stat.key}
+                                    value={stat.key ?? ""}
                                 />
                                 <input
                                     onChange={this.onChange(stat, "value")}
                                     style={{ margin: "4px" }}
                                     className={Classes.INPUT}
                                     type="text"
+                                    aria-label="custom stat value"
                                     placeholder="custom value"
-                                    value={stat.value}
+                                    value={stat.value ?? ""}
                                 />
                                 <Button
                                     icon="trash"

--- a/src/components/Editors/StatsEditor/__tests__/StatsEditor.test.tsx
+++ b/src/components/Editors/StatsEditor/__tests__/StatsEditor.test.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "utils/testUtils";
+import { vi } from "vitest";
+import { styleDefaults } from "utils/styleDefaults";
+import { StatsEditorBase } from "../StatsEditor";
+import { State } from "state";
+
+const renderEditor = (stats: State["stats"]) => {
+    const props = {
+        pokemon: [],
+        style: {
+            ...styleDefaults,
+            displayStats: true,
+        },
+        stats,
+        editStyle: vi.fn(),
+        addStat: vi.fn(),
+        editStat: vi.fn(),
+        deleteStat: vi.fn(),
+    };
+
+    render(<StatsEditorBase {...props} />);
+
+    return props;
+};
+
+describe("StatsEditorBase", () => {
+    it("edits blank imported custom stats as controlled inputs", () => {
+        const props = renderEditor([{ id: "a-1", key: undefined, value: "" }]);
+
+        fireEvent.change(screen.getByLabelText("custom stat label"), {
+            target: { value: "Attempts" },
+        });
+        fireEvent.change(screen.getByLabelText("custom stat value"), {
+            target: { value: "3" },
+        });
+
+        expect(props.editStat).toHaveBeenCalledWith("a-1", "Attempts", "");
+        expect(props.editStat).toHaveBeenCalledWith("a-1", "", "3");
+    });
+
+    it("sorts custom stats for display without mutating the stats prop", () => {
+        const stats = [
+            { id: "b-stat", key: "Second", value: "2" },
+            { id: "a-stat", key: "First", value: "1" },
+        ];
+
+        renderEditor(stats);
+
+        expect(
+            (screen.getAllByLabelText("custom stat label")[0] as HTMLInputElement)
+                .value,
+        ).toBe("First");
+        expect(stats.map((stat) => stat.id)).toEqual(["b-stat", "a-stat"]);
+    });
+});


### PR DESCRIPTION
Fixes #440.
Fixes #453.

## Summary
- Keeps StatsEditor custom stat rows sorted without mutating the stats prop/state during render.
- Keeps imported blank custom stat fields controlled with empty-string fallbacks.
- Adds accessible labels to custom stat inputs.
- Adds regression coverage for editing blank imported custom stats and preserving input order without prop mutation.

## Validation
- npm run test:run -- src/components/Editors/StatsEditor/__tests__/StatsEditor.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check