### PR TITLE
Cover Generations dead box margin

### DIFF
--- a/src/components/Features/Result/__tests__/themeCss.test.ts
+++ b/src/components/Features/Result/__tests__/themeCss.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("result theme CSS", () => {
+    it("keeps Generations dead boxes aligned with other box containers", () => {
+        const css = readFileSync(
+            join(__dirname, "../themes.css"),
+            "utf8",
+        );
+
+        expect(css).toMatch(
+            /\.generations \.boxed-container,\s*\.generations \.team-container,\s*\.generations \.dead-container,\s*\.generations \.champs-container\s*{\s*margin: 0\.5rem !important;/,
+        );
+    });
+});


### PR DESCRIPTION
Fixes #309.

## Summary
- Adds regression coverage that the Generations template keeps `.dead-container` in the shared 0.5rem container margin rule.
- Locks the existing alignment fix for Dead, Boxed, Team, and Champs containers.

## Validation
- npm run test:run -- src/components/Features/Result/__tests__/themeCss.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check