### PR TITLE
Fix duplicate checkpoint editing

### DIFF
--- a/src/actions/deleteCheckpoint.ts
+++ b/src/actions/deleteCheckpoint.ts
@@ -5,18 +5,22 @@ export type DELETE_CHECKPOINT = "DELETE_CHECKPOINT";
 export const DELETE_CHECKPOINT: DELETE_CHECKPOINT = "DELETE_CHECKPOINT";
 
 export interface DeleteCheckpointAction
-    extends Action<DELETE_CHECKPOINT, Badge["name"]> {
+    extends Action<DELETE_CHECKPOINT, Badge["name"] | number | undefined> {
     name: Badge["name"];
+    index?: number;
 }
 
 export type deleteCheckpoint = (
     name: Badge["name"],
+    index?: number,
 ) => DeleteCheckpointAction;
 export const deleteCheckpoint = (
     name: Badge["name"],
+    index?: number,
 ): DeleteCheckpointAction => {
     return {
         type: DELETE_CHECKPOINT,
         name,
+        index,
     };
 };

--- a/src/actions/editCheckpoint.ts
+++ b/src/actions/editCheckpoint.ts
@@ -5,22 +5,29 @@ export type EDIT_CHECKPOINT = "EDIT_CHECKPOINT";
 export const EDIT_CHECKPOINT: EDIT_CHECKPOINT = "EDIT_CHECKPOINT";
 
 export interface EditCheckpointAction
-    extends Action<EDIT_CHECKPOINT, Partial<Badge> | Badge["name"]> {
+    extends Action<
+        EDIT_CHECKPOINT,
+        Partial<Badge> | Badge["name"] | number | undefined
+    > {
     edits: Partial<Badge>;
     name: Badge["name"];
+    index?: number;
 }
 
 export type editCheckpoint = (
     edits: Partial<Badge>,
     name: Badge["name"],
+    index?: number,
 ) => EditCheckpointAction;
 export const editCheckpoint = (
     edits: Partial<Badge>,
     name: Badge["name"],
+    index?: number,
 ): EditCheckpointAction => {
     return {
         type: EDIT_CHECKPOINT,
         edits,
         name,
+        index,
     };
 };

--- a/src/components/Editors/TrainerEditor/CheckpointsEditor.tsx
+++ b/src/components/Editors/TrainerEditor/CheckpointsEditor.tsx
@@ -25,7 +25,8 @@ import { ImageUpload } from "components/Common/Shared/ImageUpload";
 
 export interface CheckpointsSelectProps {
     checkpoint: Badge;
-    onEdit: (img, name) => void;
+    checkpointIndex: number;
+    onEdit: (img, name, index?: number) => void;
 }
 
 export interface CheckpointsSelectState {
@@ -57,7 +58,11 @@ export class CheckpointsSelect extends React.Component<
                     return (
                         <Button
                             onClick={(e) =>
-                                this.props.onEdit({ image: badge.image }, name)
+                                this.props.onEdit(
+                                    { image: badge.image },
+                                    name,
+                                    this.props.checkpointIndex,
+                                )
                             }
                             key={key}
                             name={badge.name}
@@ -169,6 +174,7 @@ export class CheckpointsEditorBase extends React.Component<
                                     this.props.editCheckpoint(
                                         { name: e.target.value },
                                         checkpoint.name,
+                                        key,
                                     )
                                 }
                                 className={Classes.INPUT}
@@ -177,8 +183,11 @@ export class CheckpointsEditorBase extends React.Component<
                             />
                         </div>
                         <CheckpointsSelect
-                            onEdit={(i, n) => this.props.editCheckpoint(i, n)}
+                            onEdit={(i, n, index) =>
+                                this.props.editCheckpoint(i, n, index)
+                            }
                             checkpoint={checkpoint}
+                            checkpointIndex={key}
                         />
                         <div className={Classes.INPUT_GROUP}>
                             <Icon icon={"link"} />
@@ -191,6 +200,7 @@ export class CheckpointsEditorBase extends React.Component<
                                     this.props.editCheckpoint(
                                         { image: e.target.value },
                                         checkpoint.name,
+                                        key,
                                     )
                                 }
                             />
@@ -208,6 +218,7 @@ export class CheckpointsEditorBase extends React.Component<
                                         this.props.editCheckpoint(
                                             { image },
                                             checkpoint.name,
+                                            key,
                                         );
                                     }}
                                 />
@@ -216,7 +227,10 @@ export class CheckpointsEditorBase extends React.Component<
                         <Icon
                             style={{ cursor: "pointer" }}
                             onClick={(e) =>
-                                this.props.deleteCheckpoint(checkpoint.name)
+                                this.props.deleteCheckpoint(
+                                    checkpoint.name,
+                                    key,
+                                )
                             }
                             className={cx(styles.checkpointDelete)}
                             icon="trash"

--- a/src/reducers/__tests__/checkpoints.test.ts
+++ b/src/reducers/__tests__/checkpoints.test.ts
@@ -19,6 +19,20 @@ describe("checkpoints", () => {
         expect(subject.length).toBe(0);
     });
 
+    it("deletes one checkpoint by index when names are duplicated", () => {
+        const subject = checkpoints(
+            [
+                { name: "Boulder Badge", image: "boulder-badge" },
+                { name: "Boulder Badge", image: "unknown" },
+            ],
+            deleteCheckpoint("Boulder Badge", 1),
+        );
+
+        expect(subject).toEqual([
+            { name: "Boulder Badge", image: "boulder-badge" },
+        ]);
+    });
+
     it("works with edit", () => {
         const state3 = genState();
         const subject = checkpoints(
@@ -26,5 +40,20 @@ describe("checkpoints", () => {
             editCheckpoint({ image: "test" }, "TestBadge"),
         );
         expect(subject[0].image).toBe("test");
+    });
+
+    it("edits the checkpoint at the provided index when names are duplicated", () => {
+        const subject = checkpoints(
+            [
+                { name: "Boulder Badge", image: "boulder-badge" },
+                { name: "Boulder Badge", image: "unknown" },
+            ],
+            editCheckpoint({ name: "Boulder Badge 2" }, "Boulder Badge", 1),
+        );
+
+        expect(subject).toEqual([
+            { name: "Boulder Badge", image: "boulder-badge" },
+            { name: "Boulder Badge 2", image: "unknown" },
+        ]);
     });
 });

--- a/src/reducers/checkpoints.ts
+++ b/src/reducers/checkpoints.ts
@@ -20,6 +20,18 @@ import { getBadges, Game } from "utils";
 
 export type Checkpoints = Badge[];
 
+const getCheckpointIndex = (
+    state: Checkpoints,
+    name: Badge["name"],
+    index?: number,
+) => {
+    if (typeof index === "number" && state[index]?.name === name) {
+        return index;
+    }
+
+    return state.map((n) => n.name).indexOf(name);
+};
+
 export function checkpoints(
     state: Checkpoints = getBadges("None"),
     action: ReturnType<
@@ -45,9 +57,11 @@ export function checkpoints(
         case SYNC_STATE_FROM_HISTORY:
             return action.syncWith.checkpoints ?? state;
         case EDIT_CHECKPOINT: {
-            const checkpointIndex = state
-                .map((n) => n.name)
-                .indexOf(action.name);
+            const checkpointIndex = getCheckpointIndex(
+                state,
+                action.name,
+                action.index,
+            );
             const checkpoint = state[checkpointIndex];
             if (checkpointIndex < 0 || !checkpoint) {
                 return state;
@@ -65,6 +79,13 @@ export function checkpoints(
             return newState;
         }
         case DELETE_CHECKPOINT:
+            if (
+                typeof action.index === "number" &&
+                state[action.index]?.name === action.name
+            ) {
+                return state.filter((_, index) => index !== action.index);
+            }
+
             return state.filter((c) => c.name !== action.name);
         default:
             return state;


### PR DESCRIPTION
Fixes #623.

## Summary
- allow checkpoint edit/delete actions to target a row index when duplicate checkpoint names exist
- pass the row index from the custom checkpoint editor for name, image, upload, and delete actions
- add reducer regressions for duplicate checkpoint names

## Validation
- npm run test:run -- src/reducers/__tests__/checkpoints.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check