### PR TITLE
Fix evolution type lookup by game

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -231,6 +231,7 @@ export class CurrentPokemonEditBase extends React.Component<
             types: matchSpeciesToTypes(
                 species,
                 (pokemon?.forme || "Normal") as keyof typeof Forme,
+                getGameGeneration(this.props.game.name as Game),
             ),
         };
 

--- a/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
+++ b/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
@@ -1,0 +1,50 @@
+import { vi } from "vitest";
+
+import {
+    CurrentPokemonEditBase,
+    CurrentPokemonEditProps,
+} from "../CurrentPokemonEdit";
+
+describe("<CurrentPokemonEdit />", () => {
+    it("uses the current game generation when evolving Pokemon", () => {
+        const editPokemon = vi.fn();
+        const props = {
+            selectedId: "togepi",
+            box: [],
+            pokemon: [
+                {
+                    id: "togepi",
+                    position: 0,
+                    species: "Togepi",
+                    status: "Team",
+                    gender: "genderless",
+                    met: "",
+                    nature: "None",
+                    ability: "",
+                    types: ["Normal", "Normal"],
+                    egg: false,
+                    gameOfOrigin: "SoulSilver",
+                },
+            ],
+            selectPokemon: vi.fn(),
+            editPokemon,
+            addPokemon: vi.fn(),
+            game: { name: "SoulSilver", customName: "" },
+            editor: { minimized: false },
+            customTypes: [],
+            customAreas: [],
+        } as CurrentPokemonEditProps;
+        const subject = new CurrentPokemonEditBase(props);
+
+        subject.state = { ...subject.state, selectedId: "togepi" };
+        subject["evolvePokemon"]("Togetic")({});
+
+        expect(editPokemon).toHaveBeenCalledWith(
+            {
+                species: "Togetic",
+                types: ["Normal", "Flying"],
+            },
+            "togepi",
+        );
+    });
+});


### PR DESCRIPTION
Fixes #396.

## Summary
- pass the active game generation into evolution type matching
- add a regression for SoulSilver Togepi evolving into Normal/Flying Togetic

## Validation
- npm run test:run -- src/components/Editors/PokemonEditor/__tests__/CurrentPokemonEdit.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check