### PR TITLE
Fix compact boxed Pokemon width

### DIFF
--- a/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
+++ b/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
@@ -23,6 +23,7 @@ const determineWidth = (isMinimal, numerator): string => {
 // @TODO: fix this messy prop soup
 export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
     const isMinimal = poke?.style?.minimalBoxedLayout;
+    const useAutoWidth = isMinimal || poke?.style?.template === "Compact";
     const useGameOfOriginColor =
         poke?.gameOfOrigin &&
         poke?.style?.displayGameOriginForBoxedAndDead &&
@@ -42,7 +43,7 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
                           )
                         : getContrastColor(getAccentColor(poke)),
                 width: determineWidth(
-                    isMinimal,
+                    useAutoWidth,
                     poke?.style.boxedPokemonPerLine,
                 ),
             }}

--- a/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
+++ b/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
@@ -18,4 +18,21 @@ describe(BoxedPokemonBase.name, () => {
             PokemonFixtures.Pikachu.nickname,
         );
     });
+
+    it("uses auto width for compact boxed Pokemon without hiding details", async () => {
+        // @ts-expect-error - Test props may not match full interface
+        const props: BoxedPokemonProps = {
+            ...PokemonFixtures.Pikachu,
+            style: { ...styleDefaults, template: "Compact" },
+        };
+
+        const { container } = render(<BoxedPokemonBase {...props} />);
+        const boxedPokemon = container.firstElementChild as HTMLElement;
+
+        expect(boxedPokemon.style.width).toBe("auto");
+        await waitFor(() => screen.getByTestId("boxed-pokemon-name"));
+        expect(screen.getByTestId("boxed-pokemon-name").textContent).toContain(
+            PokemonFixtures.Pikachu.nickname,
+        );
+    });
 });


### PR DESCRIPTION
Fixes #197.

## Summary
- use auto width for boxed Pokemon when the Compact template is active
- keep Compact details visible instead of treating the row as minimal layout
- add a regression for compact boxed rows

## Validation
- npm run test:run -- src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check