### PR TITLE
Fix zoom menu dark mode

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -84,11 +84,18 @@ type ZoomValue = (typeof ZoomValues)[number];
 
 const convertToPercentage = (n: number) => `${n * 100}%`;
 
-const TopBarItems = ({ editorDarkMode, setZoomLevel, currentZoomLevel }) => {
+export const TopBarItems = ({
+    editorDarkMode,
+    setZoomLevel,
+    currentZoomLevel,
+}) => {
     // @TODO: make this look decent
     return (
         <Select<ZoomValue>
-            className={cx({ "bp5-dark": editorDarkMode })}
+            className={cx({ [Classes.DARK]: editorDarkMode })}
+            popoverProps={{
+                popoverClassName: cx({ [Classes.DARK]: editorDarkMode }),
+            }}
             filterable={false}
             items={ZoomValues}
             itemRenderer={(item, { handleClick }) => (

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 
-import { ResultBase, BackspriteMontage } from "../Result";
+import { ResultBase, BackspriteMontage, TopBarItems } from "../Result";
 import { styleDefaults, generateEmptyPokemon } from "utils";
 import { Editor, Box, Pokemon } from "models";
 
@@ -9,6 +9,17 @@ type ResultBaseProps = React.ComponentProps<typeof ResultBase>;
 type PokemonSpeciesProps = { species: string };
 type PokemonProp = { pokemon: Pokemon };
 type ChildrenProps = { children?: React.ReactNode };
+type SelectProps = {
+    children?: React.ReactNode;
+    className?: string;
+    popoverProps?: {
+        popoverClassName?: string;
+    };
+};
+
+const selectMockState = vi.hoisted(() => ({
+    latestProps: undefined as SelectProps | undefined,
+}));
 
 vi.mock("components/Pokemon/TeamPokemon/TeamPokemon", () => ({
     TeamPokemon: ({ pokemon }: PokemonProp) => (
@@ -60,6 +71,13 @@ vi.mock("components/Common/Shared/PokemonImage", () => ({
     }) => <>{children("https://img.test")}</>,
 }));
 
+vi.mock("@blueprintjs/select", () => ({
+    Select: (props: SelectProps) => {
+        selectMockState.latestProps = props;
+        return <div data-testid="zoom-select">{props.children}</div>;
+    },
+}));
+
 vi.mock("components/ui/shims", () => ({
     Select: ({ children }: ChildrenProps) => <div data-testid="zoom-select">{children}</div>,
     Button: ({ children }: ChildrenProps) => <button>{children}</button>,
@@ -94,6 +112,21 @@ const createPokemon = () => [
 ];
 
 describe("<ResultBase />", () => {
+    it("applies dark mode to the zoom select popover", () => {
+        render(
+            <TopBarItems
+                editorDarkMode={true}
+                setZoomLevel={vi.fn()}
+                currentZoomLevel={1}
+            />,
+        );
+
+        expect(selectMockState.latestProps?.className).toContain("dark");
+        expect(
+            selectMockState.latestProps?.popoverProps?.popoverClassName,
+        ).toContain("dark");
+    });
+
     it("renders team and status sections with rules", () => {
         render(
             <ResultBase


### PR DESCRIPTION
Fixes #425.

## Summary
- apply Blueprint dark mode to the zoom Select portal popover
- use the Blueprint dark class constant for the zoom select target
- add a regression asserting the zoom select and popover both receive dark styling

## Validation
- npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
- Browser smoke on http://127.0.0.1:8086: toggled dark mode, opened zoom menu, confirmed .bp5-popover includes bp5-dark and menu item text computed as rgb(246, 247, 249)