### PR TITLE
Fix sprite image backdrop

### DIFF
--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -584,6 +584,15 @@ export class TeamPokemonBase extends React.Component<
         };
 
         const EMMA_MODE = false;
+        const imageWrapperBackground = style.spritesMode
+            ? "#fff"
+            : this.props.style.teamPokemonBorder
+              ? getBackgroundGradient(
+                    poke.types != null && !poke.egg ? poke.types[0] : "Normal",
+                    poke.types != null && !poke.egg ? poke.types[1] : "Normal",
+                    customTypes,
+                )
+              : "transparent";
 
         return (
             <div className="pokemon-container" {...data}>
@@ -598,17 +607,7 @@ export class TeamPokemonBase extends React.Component<
                             className={`${this.props.style.imageStyle} pokemon-image-wrapper`}
                             style={{
                                 cursor: "pointer",
-                                background: this.props.style.teamPokemonBorder
-                                    ? getBackgroundGradient(
-                                          poke.types != null && !poke.egg
-                                              ? poke.types[0]
-                                              : "Normal",
-                                          poke.types != null && !poke.egg
-                                              ? poke.types[1]
-                                              : "Normal",
-                                          customTypes,
-                                      )
-                                    : "transparent",
+                                background: imageWrapperBackground,
                             }}
                         />
                         <PokemonImage
@@ -648,17 +647,7 @@ export class TeamPokemonBase extends React.Component<
                         className={`${this.props.style.imageStyle} pokemon-image-wrapper`}
                         style={{
                             cursor: "pointer",
-                            background: this.props.style.teamPokemonBorder
-                                ? getBackgroundGradient(
-                                      poke.types != null && !poke.egg
-                                          ? poke.types[0]
-                                          : "Normal",
-                                      poke.types != null && !poke.egg
-                                          ? poke.types[1]
-                                          : "Normal",
-                                      customTypes,
-                                  )
-                                : "transparent",
+                            background: imageWrapperBackground,
                         }}
                     >
                         <PokemonImage

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
@@ -111,6 +111,27 @@ describe("TeamPokemonBase", () => {
         expect(selectPokemon).toHaveBeenCalledWith(basePokemon.id);
     });
 
+    it("uses a neutral image backdrop in sprite mode", () => {
+        render(
+            <TeamPokemonBase
+                pokemon={{ ...basePokemon, species: "Poliwrath" }}
+                style={{
+                    ...baseStyle,
+                    spritesMode: true,
+                    teamPokemonBorder: true,
+                }}
+                game={{ name: "FireRed", customName: "" }}
+                selectPokemon={vi.fn()}
+                editor={baseEditor}
+                customTypes={[]}
+            />,
+        );
+
+        expect(screen.getByRole("presentation").style.background).toBe(
+            "rgb(255, 255, 255)",
+        );
+    });
+
     it("shows MVP label when pokemon is marked as MVP", () => {
         render(
             <TeamPokemonBase


### PR DESCRIPTION
Fixes #931.

## Summary
- use a neutral image-wrapper backdrop when sprites mode is enabled
- keep type-gradient image backgrounds for non-sprite team images
- add a Poliwrath/FireRed sprite-mode regression

## Validation
- npm run test:run -- src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check