### PR TITLE
Fix sprite mode proxy fetches

### DIFF
--- a/src/utils/getters/__tests__/getPokemonImage.test.ts
+++ b/src/utils/getters/__tests__/getPokemonImage.test.ts
@@ -165,7 +165,7 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
     });
 
     describe("spritesMode (remote sprite URLs)", () => {
-        it("builds serebii non-shiny sprite URL for BW-era games and wraps it", async () => {
+        it("builds serebii non-shiny sprite URL for BW-era games without proxying it", async () => {
             const result = await getPokemonImage({
                 species: "Pikachu",
                 forme: imageForme("Alolan"),
@@ -176,11 +176,11 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
 
             const expectedUrl =
                 "https://www.serebii.net/blackwhite/pokemon/025-Alolan.png";
-            expect(mocks.wrapImageInCORS).toHaveBeenCalledWith(expectedUrl);
-            expect(result).toBe(`cors(${expectedUrl})`);
+            expect(mocks.wrapImageInCORS).not.toHaveBeenCalled();
+            expect(result).toBe(`url(${expectedUrl})`);
         });
 
-        it("builds serebii shiny sprite URL for BW-era games and wraps it", async () => {
+        it("builds serebii shiny sprite URL for BW-era games without proxying it", async () => {
             const result = await getPokemonImage({
                 species: "Pikachu",
                 name: imageGame("Black"),
@@ -189,11 +189,11 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             });
 
             const expectedUrl = "https://www.serebii.net/Shiny/BW/025.png";
-            expect(mocks.wrapImageInCORS).toHaveBeenCalledWith(expectedUrl);
-            expect(result).toBe(`cors(${expectedUrl})`);
+            expect(mocks.wrapImageInCORS).not.toHaveBeenCalled();
+            expect(result).toBe(`url(${expectedUrl})`);
         });
 
-        it("builds Scarlet/Violet sprite URLs and wraps them", async () => {
+        it("builds Scarlet/Violet sprite URLs without proxying them", async () => {
             const nonShiny = await getPokemonImage({
                 species: "Pikachu",
                 name: imageGame("Scarlet"),
@@ -208,14 +208,15 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             });
 
             expect(nonShiny).toBe(
-                "cors(https://serebii.net/scarletviolet/pokemon/new/025.png)",
+                "url(https://serebii.net/scarletviolet/pokemon/new/025.png)",
             );
             expect(shiny).toBe(
-                "cors(https://serebii.net/Shiny/SV/new/025.png)",
+                "url(https://serebii.net/Shiny/SV/new/025.png)",
             );
+            expect(mocks.wrapImageInCORS).not.toHaveBeenCalled();
         });
 
-        it("builds DP/HGSS sprite URLs and wraps them", async () => {
+        it("builds DP/HGSS sprite URLs without proxying them", async () => {
             const nonShiny = await getPokemonImage({
                 species: "Pikachu",
                 name: imageGame("Diamond"),
@@ -230,12 +231,13 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             });
 
             expect(nonShiny).toBe(
-                "cors(https://www.serebii.net/pokearth/sprites/dp/025.png)",
+                "url(https://www.serebii.net/pokearth/sprites/dp/025.png)",
             );
-            expect(shiny).toBe("cors(https://www.serebii.net/Shiny/DP/025.png)");
+            expect(shiny).toBe("url(https://www.serebii.net/Shiny/DP/025.png)");
+            expect(mocks.wrapImageInCORS).not.toHaveBeenCalled();
         });
 
-        it("builds FRLG sprite URLs via pokemondb and wraps them", async () => {
+        it("builds FRLG sprite URLs via pokemondb without proxying them", async () => {
             const nonShiny = await getPokemonImage({
                 species: "Pikachu",
                 name: imageGame("FireRed"),
@@ -251,14 +253,15 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
 
             expect(mocks.normalizeSpeciesName).toHaveBeenCalledWith("Pikachu");
             expect(nonShiny).toBe(
-                "cors(https://img.pokemondb.net/sprites/firered-leafgreen/normal/pikachu.png)",
+                "url(https://img.pokemondb.net/sprites/firered-leafgreen/normal/pikachu.png)",
             );
             expect(shiny).toBe(
-                "cors(https://img.pokemondb.net/sprites/firered-leafgreen/shiny/pikachu.png)",
+                "url(https://img.pokemondb.net/sprites/firered-leafgreen/shiny/pikachu.png)",
             );
+            expect(mocks.wrapImageInCORS).not.toHaveBeenCalled();
         });
 
-        it("builds Sword/Shield sprite URLs and wraps them", async () => {
+        it("builds Sword/Shield sprite URLs without proxying them", async () => {
             const nonShiny = await getPokemonImage({
                 species: "Pikachu",
                 forme: imageForme("Alolan"),
@@ -274,11 +277,12 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             });
 
             expect(nonShiny).toBe(
-                "cors(https://www.serebii.net/swordshield/pokemon/025-Alolan.png)",
+                "url(https://www.serebii.net/swordshield/pokemon/025-Alolan.png)",
             );
             expect(shiny).toBe(
-                "cors(https://www.serebii.net/Shiny/SWSH/025.png)",
+                "url(https://www.serebii.net/Shiny/SWSH/025.png)",
             );
+            expect(mocks.wrapImageInCORS).not.toHaveBeenCalled();
         });
 
         it("uses generic serebii URL builder for other games when spritesMode is true", async () => {
@@ -290,7 +294,7 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
             });
 
             expect(result).toBe(
-                "cors(https://www.serebii.net/green/pokemon/025.png)",
+                "url(https://www.serebii.net/green/pokemon/025.png)",
             );
         });
     });
@@ -408,4 +412,3 @@ describe("@src/utils/getters/getPokemonImage.ts", () => {
         });
     });
 });
-

--- a/src/utils/getters/getPokemonImage.ts
+++ b/src/utils/getters/getPokemonImage.ts
@@ -126,6 +126,8 @@ const getGameNameSerebii = (name: Game) => {
     }
 };
 
+const remoteSpriteUrl = (url: string) => `url(${url})`;
+
 export interface GetPokemonImage {
     customImage?: string;
     forme?: Pokemon["forme"] | keyof typeof Forme;
@@ -205,13 +207,13 @@ export async function getPokemonImage({
                 name,
             )}/pokemon/${leadingZerosNumber}${getForme(forme)}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         } else {
             const url = `https://www.serebii.net/Shiny/${capitalize(
                 getGameNameSerebii(name as Game),
             )}/${leadingZerosNumber}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         }
     }
 
@@ -219,11 +221,11 @@ export async function getPokemonImage({
         if (!shiny) {
             const url = `https://serebii.net/scarletviolet/pokemon/new/${leadingZerosNumber}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         } else {
             const url = `https://serebii.net/Shiny/SV/new/${leadingZerosNumber}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         }
     }
 
@@ -231,11 +233,11 @@ export async function getPokemonImage({
         if (!shiny) {
             const url = `https://www.serebii.net/pokearth/sprites/dp/${leadingZerosNumber}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         } else {
             const url = `https://www.serebii.net/Shiny/DP/${leadingZerosNumber}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         }
     }
 
@@ -245,13 +247,13 @@ export async function getPokemonImage({
                 species as Species,
             )}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         } else {
             const url = `https://img.pokemondb.net/sprites/firered-leafgreen/shiny/${normalizeSpeciesName(
                 species as Species,
             )}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         }
     }
 
@@ -261,10 +263,10 @@ export async function getPokemonImage({
                 name,
             )}/pokemon/${leadingZerosNumber}${getForme(forme)}.png`;
 
-            return await wrapImageInCORS(url);
+            return remoteSpriteUrl(url);
         }
         const url = `https://www.serebii.net/Shiny/SWSH/${leadingZerosNumber}.png`;
-        return await wrapImageInCORS(url);
+        return remoteSpriteUrl(url);
     }
 
     if (style?.spritesMode) {
@@ -274,7 +276,7 @@ export async function getPokemonImage({
               )}/${leadingZerosNumber}.png`
             : `https://www.serebii.net/${getGameName(name as Game)}/pokemon/${leadingZerosNumber}.png`;
 
-        return await wrapImageInCORS(url);
+        return remoteSpriteUrl(url);
     }
 
     if (style?.teamImages === "sugimori") {


### PR DESCRIPTION
Fixes #553. Fixes #522. Fixes #494. Fixes #483. Fixes #472. Fixes #471. Fixes #466. Fixes #445.

## Summary
- Return direct CSS image URLs for sprite-mode generated remote sprites instead of sending every sprite through the CORS proxy
- Keep custom remote images on the existing CORS-safe path
- Update sprite URL tests to assert sprite mode no longer calls the proxy helper

## Validation
- npm run test:run -- src/utils/getters/__tests__/getPokemonImage.test.ts src/components/Common/Shared/__tests__/PokemonImage.test.tsx
- Browser smoke at http://127.0.0.1:8087 with FireRed sprite mode: rendered Bulbasaur/Pidgey PokemonDB background URLs and zero cors-anywhere resource entries
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check