### PR TITLE
Fix vertical Hexagons five-slot layout

### DIFF
--- a/src/components/Features/Result/themes.css
+++ b/src/components/Features/Result/themes.css
@@ -354,6 +354,10 @@
 .hexagons.team-size-5 .pokemon-container:nth-of-type(5) {
     transform: translate(-248px, -62px);
 }
+.hexagons.team-size-5.vertical-trainer .pokemon-container:nth-of-type(4),
+.hexagons.team-size-5.vertical-trainer .pokemon-container:nth-of-type(5) {
+    transform: translate(0, -62px);
+}
 .hexagons.team-size-4 .team-container,
 .hexagons.team-size-3 .team-container,
 .hexagons.team-size-2 .team-container,


### PR DESCRIPTION
Fixes #837.

## Summary
- Add a scoped Hexagons override for the five-member vertical-trainer layout
- Keep the existing horizontal Hexagons transforms unchanged
- Prevent the fourth/fifth party slot from being translated below the result area

## Validation
- Browser reproduction at http://127.0.0.1:8088 with the #837 payload: before the fix, one slot bottom was below the result; after the fix, all five team slots are within the result area
- Browser check with horizontal trainer: existing team-size-5 transforms remain unchanged
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check