### PR TITLE
Fix stats offset with vertical trainer

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -648,7 +648,9 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
                         </div>
 
                         {enableStats && !EMMA_MODE && (
-                            <Stats color={getContrastColor(bgColor)} />
+                            <div style={paddingForVerticalTrainerSection}>
+                                <Stats color={getContrastColor(bgColor)} />
+                            </div>
                         )}
 
                         {enableBackSpriteMontage && (

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -38,6 +38,10 @@ vi.mock("components/Features/Result/TrainerResult", () => ({
     TrainerResult: () => <div data-testid="trainer-result" />,
 }));
 
+vi.mock("../Stats", () => ({
+    Stats: () => <div className="stats stats-container" data-testid="stats" />,
+}));
+
 vi.mock("components/Layout/TopBar/TopBar", () => ({
     TopBar: ({ children }: { children?: React.ReactNode }) => (
         <div data-testid="top-bar">{children}</div>
@@ -123,6 +127,35 @@ describe("<ResultBase />", () => {
         expect(screen.getByText("Boxed")).toBeTruthy();
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
+    });
+
+    it("offsets stats from the vertical trainer section", () => {
+        const { container } = render(
+            <ResultBase
+                pokemon={createPokemon()}
+                game={{ name: "Red", customName: "" }}
+                trainer={{ badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    displayStats: true,
+                    trainerSectionOrientation: "vertical",
+                    trainerWidth: "25%",
+                }}
+                rules={[]}
+                customTypes={[]}
+            />,
+        );
+
+        const statsContainer = container.querySelector(".stats-container");
+
+        expect(statsContainer?.parentElement?.style.paddingLeft).toBe("25%");
     });
 });
 


### PR DESCRIPTION
Fixes #866.

## Summary
- Wrap the Stats result section with the same vertical-trainer padding used by other result content
- Add a Result regression test that asserts stats are offset by trainerWidth in vertical trainer mode

## Validation
- npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx
- Browser smoke at http://127.0.0.1:8089 with vertical trainer + stats enabled: stats left edge cleared trainer right edge and parent padding was 300px
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check