### PR TITLE
Add separate game-origin toggles for boxed and dead Pokemon

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -817,6 +817,60 @@ export class StyleEditorBase extends React.Component<
                     }
                 >
                     <Checkbox
+                        checked={
+                            props.style.displayGameOriginForBoxedPokemon !==
+                            false
+                        }
+                        name="displayGameOriginForBoxedPokemon"
+                        label="Display Game Origin for Boxed Pokémon"
+                        onChange={(e) => editCheckboxEvent(e, props, "displayGameOriginForBoxedPokemon")}
+                    />
+                </div>
+
+                <div
+                    className={styleEdit}
+                    style={
+                        {
+                            marginLeft: "1rem",
+                            opacity: props.style
+                                .displayGameOriginForBoxedAndDead
+                                ? "1"
+                                : "0.3",
+                            pointerEvents: props.style
+                                .displayGameOriginForBoxedAndDead
+                                ? undefined
+                                : "none",
+                        } as React.CSSProperties
+                    }
+                >
+                    <Checkbox
+                        checked={
+                            props.style.displayGameOriginForDeadPokemon !==
+                            false
+                        }
+                        name="displayGameOriginForDeadPokemon"
+                        label="Display Game Origin for Dead Pokémon"
+                        onChange={(e) => editCheckboxEvent(e, props, "displayGameOriginForDeadPokemon")}
+                    />
+                </div>
+
+                <div
+                    className={styleEdit}
+                    style={
+                        {
+                            marginLeft: "1rem",
+                            opacity: props.style
+                                .displayGameOriginForBoxedAndDead
+                                ? "1"
+                                : "0.3",
+                            pointerEvents: props.style
+                                .displayGameOriginForBoxedAndDead
+                                ? undefined
+                                : "none",
+                        } as React.CSSProperties
+                    }
+                >
+                    <Checkbox
                         checked={props.style.displayBackgroundInsteadOfBadge}
                         name="displayBackgroundInsteadOfBadge"
                         label="Display Background Color Instead of Badge"

--- a/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
+++ b/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
@@ -23,9 +23,12 @@ const determineWidth = (isMinimal, numerator): string => {
 // @TODO: fix this messy prop soup
 export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
     const isMinimal = poke?.style?.minimalBoxedLayout;
+    const displayGameOrigin =
+        poke?.style?.displayGameOriginForBoxedAndDead &&
+        poke?.style?.displayGameOriginForBoxedPokemon !== false;
     const useGameOfOriginColor =
         poke?.gameOfOrigin &&
-        poke?.style?.displayGameOriginForBoxedAndDead &&
+        displayGameOrigin &&
         poke?.style?.displayBackgroundInsteadOfBadge;
     return (
         <div
@@ -81,7 +84,7 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
                     >
                         {poke?.nickname} {GenderElement(poke?.gender)}{" "}
                         {poke?.level ? <span>lv. {poke?.level}</span> : null}
-                        {poke?.style?.displayGameOriginForBoxedAndDead &&
+                        {displayGameOrigin &&
                             !poke?.style?.displayBackgroundInsteadOfBadge &&
                             poke?.gameOfOrigin && (
                                 <span

--- a/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
+++ b/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
@@ -18,4 +18,38 @@ describe(BoxedPokemonBase.name, () => {
             PokemonFixtures.Pikachu.nickname,
         );
     });
+
+    it("can hide game origin for boxed pokemon while the global option is enabled", () => {
+        // @ts-expect-error - Test props may not match full interface
+        const props: BoxedPokemonProps = {
+            ...PokemonFixtures.Pikachu,
+            gameOfOrigin: "Red",
+            style: {
+                ...styleDefaults,
+                displayGameOriginForBoxedAndDead: true,
+                displayGameOriginForBoxedPokemon: false,
+                displayGameOriginForDeadPokemon: true,
+            },
+        };
+
+        render(<BoxedPokemonBase {...props} />);
+
+        expect(screen.queryByText("Red")).toBeNull();
+    });
+
+    it("shows game origin for boxed pokemon by default when the global option is enabled", () => {
+        // @ts-expect-error - Test props may not match full interface
+        const props: BoxedPokemonProps = {
+            ...PokemonFixtures.Pikachu,
+            gameOfOrigin: "Red",
+            style: {
+                ...styleDefaults,
+                displayGameOriginForBoxedAndDead: true,
+            },
+        };
+
+        render(<BoxedPokemonBase {...props} />);
+
+        expect(screen.getByText("Red")).toBeTruthy();
+    });
 });

--- a/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
+++ b/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
@@ -101,7 +101,11 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
     const useGameOfOriginColor =
         poke.gameOfOrigin &&
         poke.style.displayGameOriginForBoxedAndDead &&
+        poke.style.displayGameOriginForDeadPokemon !== false &&
         poke.style.displayBackgroundInsteadOfBadge;
+    const displayGameOrigin =
+        poke.style.displayGameOriginForBoxedAndDead &&
+        poke.style.displayGameOriginForDeadPokemon !== false;
     const EMMA_MODE = feature.emmaMode;
 
     if (isMinimal && isCompactWithIcons) {
@@ -172,7 +176,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                         <div data-testid="cause-of-death">
                             {poke.causeOfDeath}
                         </div>
-                        {style.displayGameOriginForBoxedAndDead &&
+                        {displayGameOrigin &&
                             !poke.style.displayBackgroundInsteadOfBadge &&
                             poke.gameOfOrigin && (
                                 <span
@@ -242,7 +246,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                         {poke.level}
                     </div>
                     <div data-testid="cause-of-death">{poke.causeOfDeath}</div>
-                    {style.displayGameOriginForBoxedAndDead &&
+                    {displayGameOrigin &&
                         !poke.style.displayBackgroundInsteadOfBadge &&
                         poke.gameOfOrigin && (
                             <span
@@ -328,7 +332,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                 >
                     {poke.causeOfDeath}
                 </div>
-                {style.displayGameOriginForBoxedAndDead &&
+                {displayGameOrigin &&
                     !poke.style.displayBackgroundInsteadOfBadge &&
                     poke.gameOfOrigin && (
                         <span

--- a/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
+++ b/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
@@ -27,4 +27,42 @@ describe("<DeadPokemon />", () => {
             poke.causeOfDeath,
         );
     });
+
+    it("can hide game origin for dead pokemon while the global option is enabled", () => {
+        render(
+            <DeadPokemonBase
+                game={{ name: "Red", customName: "" }}
+                style={{
+                    ...styleDefaults,
+                    displayGameOriginForBoxedAndDead: true,
+                    displayGameOriginForBoxedPokemon: true,
+                    displayGameOriginForDeadPokemon: false,
+                }}
+                selectPokemon={vi.fn()}
+                minimal={false}
+                {...poke}
+                gameOfOrigin="Red"
+            />,
+        );
+
+        expect(screen.queryByText("Red")).toBeNull();
+    });
+
+    it("shows game origin for dead pokemon by default when the global option is enabled", () => {
+        render(
+            <DeadPokemonBase
+                game={{ name: "Red", customName: "" }}
+                style={{
+                    ...styleDefaults,
+                    displayGameOriginForBoxedAndDead: true,
+                }}
+                selectPokemon={vi.fn()}
+                minimal={false}
+                {...poke}
+                gameOfOrigin="Red"
+            />,
+        );
+
+        expect(screen.getByText("Red")).toBeTruthy();
+    });
 });

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -82,7 +82,7 @@ describe("styleDefaults", () => {
         expect(objectPropertiesWhere(styleDefaults, (p) => p === "round")).toBe(
             1,
         );
-        expect(objectPropertiesWhere(styleDefaults, (p) => Boolean(p))).toBe(28);
+        expect(objectPropertiesWhere(styleDefaults, (p) => Boolean(p))).toBe(30);
     });
 });
 

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -57,6 +57,8 @@ export interface Styles {
     useSpritesForChampsPokemon: boolean;
     boxedPokemonPerLine: number;
     displayGameOriginForBoxedAndDead: boolean;
+    displayGameOriginForBoxedPokemon: boolean;
+    displayGameOriginForDeadPokemon: boolean;
     displayBackgroundInsteadOfBadge: boolean;
     displayExtraData: boolean;
     useAutoHeight: boolean;
@@ -105,6 +107,8 @@ export const styleDefaults: Styles = {
     useSpritesForChampsPokemon: false,
     boxedPokemonPerLine: 6,
     displayGameOriginForBoxedAndDead: false,
+    displayGameOriginForBoxedPokemon: true,
+    displayGameOriginForDeadPokemon: true,
     displayBackgroundInsteadOfBadge: false,
     displayExtraData: true,
     useAutoHeight: true,


### PR DESCRIPTION
Fixes #668.

## Summary
- Adds separate style toggles for boxed and dead Pokemon game-origin display.
- Keeps the existing global Display Game Origin setting as the parent gate.
- Defaults the new section toggles on so existing saved styles keep their current behavior.
- Applies the section toggles to both game-origin badges and background-color mode.

## Validation
- npm run lint
- npm run typecheck
- npm run test:run -- src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
- npm run test:run -- src/utils/__tests__/utils.test.ts src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
- npm run test:run
- npm run build
- git diff --check
- Browser smoke on http://127.0.0.1:8090 confirmed the boxed/dead controls render checked by default and are dimmed while the global Display Game Origin switch is off.