### PR TITLE
Add quick level-up buttons to Pokemon boxes

### DIFF
--- a/src/components/Common/Shared/PokemonByFilter.tsx
+++ b/src/components/Common/Shared/PokemonByFilter.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Tooltip, Position } from "@blueprintjs/core";
+import { Button, Tooltip, Position } from "@blueprintjs/core";
 import { Pokemon } from "models";
 import { PokemonIcon } from "components/Pokemon/PokemonIcon";
 import { sortPokes } from "utils";
@@ -31,6 +31,22 @@ const SELECTION_COLOR_LIGHT = "rgba(0, 0, 0, 0.33)";
 const SELECTION_COLOR_DARK = "rgba(255, 255, 255, 0.25)";
 
 export class PokemonByFilterBase extends React.PureComponent<PokemonByFilterProps> {
+    private levelUpPokemon = (poke: Pokemon) => (
+        event: React.MouseEvent<HTMLElement>,
+    ) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const level = Number.parseInt(String(poke.level ?? "0"), 10);
+
+        this.props.editPokemon(
+            {
+                level: (Number.isNaN(level) ? 0 : level) + 1,
+            },
+            poke.id,
+        );
+    };
+
     public render() {
         const { team, status, matchedIds, hasSearchQuery, isDarkMode, selectedId } = this.props;
 
@@ -54,33 +70,55 @@ export class PokemonByFilterBase extends React.PureComponent<PokemonByFilterProp
                     backgroundColor = searchHighlightColor;
                 }
 
+                const displayName = poke.nickname || poke.species || "Pokemon";
+
                 return (
-                    <Tooltip
+                    <span
                         key={poke.id}
-                        content={poke.nickname || poke.species}
-                        position={Position.TOP}
+                        style={{
+                            alignItems: "center",
+                            display: "inline-flex",
+                            gap: "0.125rem",
+                        }}
                     >
-                        <PokemonIcon
-                            style={
-                                backgroundColor
-                                    ? {
-                                          backgroundColor,
-                                          borderRadius: "50%",
-                                      }
-                                    : undefined
-                            }
-                            id={poke.id}
-                            status={poke.status}
-                            species={poke.species}
-                            forme={poke.forme}
-                            shiny={poke.shiny}
-                            gender={poke.gender}
-                            customIcon={poke.customIcon}
-                            hidden={poke.hidden}
-                            position={poke.position}
-                            egg={poke.egg}
-                        />
-                    </Tooltip>
+                        <Tooltip
+                            content={displayName}
+                            position={Position.TOP}
+                        >
+                            <PokemonIcon
+                                style={
+                                    backgroundColor
+                                        ? {
+                                              backgroundColor,
+                                              borderRadius: "50%",
+                                          }
+                                        : undefined
+                                }
+                                id={poke.id}
+                                status={poke.status}
+                                species={poke.species}
+                                forme={poke.forme}
+                                shiny={poke.shiny}
+                                gender={poke.gender}
+                                customIcon={poke.customIcon}
+                                hidden={poke.hidden}
+                                position={poke.position}
+                                egg={poke.egg}
+                            />
+                        </Tooltip>
+                        <Tooltip
+                            content={`Level up ${displayName}`}
+                            position={Position.TOP}
+                        >
+                            <Button
+                                aria-label={`Level up ${displayName}`}
+                                icon="plus"
+                                minimal
+                                small
+                                onClick={this.levelUpPokemon(poke)}
+                            />
+                        </Tooltip>
+                    </span>
                 );
             });
     }

--- a/src/components/Common/Shared/__tests__/PokemonByFilter.test.tsx
+++ b/src/components/Common/Shared/__tests__/PokemonByFilter.test.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import { vi } from "vitest";
+
+vi.mock("components/Pokemon/PokemonIcon", () => ({
+    PokemonIcon: ({ species }: { species: string }) => (
+        <div data-testid="pokemon-icon">{species}</div>
+    ),
+}));
+
+import { fireEvent, render, screen } from "utils/testUtils";
+import { PokemonByFilterBase } from "../PokemonByFilter";
+import { Types } from "utils";
+import type { Pokemon } from "models";
+
+const basePokemon: Pokemon = {
+    id: "poke-1",
+    species: "Pikachu",
+    nickname: "Sparky",
+    level: "9" as unknown as number,
+    status: "Team",
+    types: [Types.Electric, Types.Electric],
+};
+
+const renderPokemonByFilter = (
+    pokemon: Pokemon[],
+    editPokemon = vi.fn(),
+) => {
+    render(
+        <PokemonByFilterBase
+            team={pokemon}
+            status="Team"
+            editPokemon={editPokemon}
+            searchTerm=""
+            matchedIds={new Set()}
+            hasSearchQuery={false}
+            isDarkMode={false}
+            selectedId=""
+        />,
+    );
+
+    return editPokemon;
+};
+
+describe(PokemonByFilterBase.name, () => {
+    it("adds a level-up button next to each pokemon icon", () => {
+        renderPokemonByFilter([basePokemon]);
+
+        expect(screen.getByTestId("pokemon-icon").textContent).toBe("Pikachu");
+        expect(
+            screen.getByRole("button", { name: "Level up Sparky" }),
+        ).toBeTruthy();
+    });
+
+    it("increments the selected pokemon level from the box list", () => {
+        const editPokemon = renderPokemonByFilter([basePokemon]);
+
+        fireEvent.click(screen.getByRole("button", { name: "Level up Sparky" }));
+
+        expect(editPokemon).toHaveBeenCalledWith({ level: 10 }, "poke-1");
+    });
+
+    it("starts at level 1 when the pokemon has no level yet", () => {
+        const editPokemon = renderPokemonByFilter([
+            {
+                ...basePokemon,
+                level: undefined,
+            },
+        ]);
+
+        fireEvent.click(screen.getByRole("button", { name: "Level up Sparky" }));
+
+        expect(editPokemon).toHaveBeenCalledWith({ level: 1 }, "poke-1");
+    });
+});


### PR DESCRIPTION
Fixes #678.

## Summary
- Adds a small plus-icon button beside each Pokemon icon in the editor box list.
- Clicking the button increments that Pokemon's level directly without opening the selected Pokemon editor.
- Keeps clicking the Pokemon icon itself as the existing select behavior.

## Validation
- npm run test:run -- src/components/Common/Shared/__tests__/PokemonByFilter.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
- Browser smoke on http://127.0.0.1:8091 confirmed the level-up button renders next to the Team icon and increments an empty level to 1.