### PR TITLE
Cover and label the Pokemon evolve button

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -112,8 +112,12 @@ export function EvolutionSelection({ currentPokemon, onEvolve }) {
 
     if (evos?.length === 1) {
         const species = evos?.[0];
+        const label = `Evolve ${currentPokemon.species} to ${species}`;
+
         return (
             <Button
+                aria-label={label}
+                icon="arrow-right"
                 onClick={onEvolve(species)}
                 className={Classes.MINIMAL}
                 intent={Intent.PRIMARY}
@@ -133,6 +137,7 @@ export function EvolutionSelection({ currentPokemon, onEvolve }) {
                         {evos.map((evo) => (
                             <div
                                 role="button"
+                                aria-label={`Evolve ${currentPokemon.species} to ${evo}`}
                                 tabIndex={-2}
                                 className={Styles.evoMenuItem}
                                 key={evo}
@@ -145,7 +150,12 @@ export function EvolutionSelection({ currentPokemon, onEvolve }) {
                     </>
                 }
             >
-                <Button className={Classes.MINIMAL} intent={Intent.PRIMARY}>
+                <Button
+                    aria-label={`Choose evolution for ${currentPokemon.species}`}
+                    className={Classes.MINIMAL}
+                    icon="arrow-right"
+                    intent={Intent.PRIMARY}
+                >
                     Evolve
                 </Button>
             </Popover>

--- a/src/components/Editors/PokemonEditor/__tests__/EvolutionSelection.test.tsx
+++ b/src/components/Editors/PokemonEditor/__tests__/EvolutionSelection.test.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { vi } from "vitest";
+import { fireEvent, render, screen } from "utils/testUtils";
+import { EvolutionSelection } from "../CurrentPokemonEdit";
+import { Types } from "utils";
+import type { Pokemon } from "models";
+
+const createPokemon = (species: string): Pokemon => ({
+    id: "poke-1",
+    species,
+    status: "Team",
+    types: [Types.Normal, Types.Normal],
+});
+
+describe(EvolutionSelection.name, () => {
+    it("renders a direct evolve button for pokemon with one evolution", () => {
+        const onEvolve = vi.fn(() => vi.fn());
+
+        render(
+            <EvolutionSelection
+                currentPokemon={createPokemon("Bulbasaur")}
+                onEvolve={onEvolve}
+            />,
+        );
+
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: "Evolve Bulbasaur to Ivysaur",
+            }),
+        );
+
+        expect(onEvolve).toHaveBeenCalledWith("Ivysaur");
+    });
+
+    it("renders a choice button for pokemon with multiple evolutions", () => {
+        render(
+            <EvolutionSelection
+                currentPokemon={createPokemon("Eevee")}
+                onEvolve={vi.fn(() => vi.fn())}
+            />,
+        );
+
+        expect(
+            screen.getByRole("button", { name: "Choose evolution for Eevee" }),
+        ).toBeTruthy();
+    });
+
+    it("does not render for pokemon without evolutions", () => {
+        const { container } = render(
+            <EvolutionSelection
+                currentPokemon={createPokemon("Mew")}
+                onEvolve={vi.fn(() => vi.fn())}
+            />,
+        );
+
+        expect(container.textContent).toBe("");
+    });
+});


### PR DESCRIPTION
Fixes #50.

## Summary
- Adds target-specific accessible labels to the existing Evolve control.
- Adds regression coverage for single-evolution, multi-evolution, and no-evolution Pokemon states.
- Keeps the existing direct evolve behavior and multi-evolution picker behavior intact.

## Validation
- npm run test:run -- src/components/Editors/PokemonEditor/__tests__/EvolutionSelection.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
- Browser smoke on http://127.0.0.1:8092 confirmed Bulbasaur shows `Evolve Bulbasaur to Ivysaur`, and clicking it changes the selected species to Ivysaur.