### PR TITLE
Enable Mass Editor column sorting

### DIFF
--- a/src/components/Editors/PokemonEditor/MassEditorTable.tsx
+++ b/src/components/Editors/PokemonEditor/MassEditorTable.tsx
@@ -21,6 +21,65 @@ export interface MassEditorTableProps {
     editPokemon: editPokemonType;
 }
 
+type SortDirection = "asc" | "desc";
+
+export interface MassEditorSort {
+    key: keyof Pokemon;
+    direction: SortDirection;
+}
+
+const getSortValue = (pokemon: Pokemon, key: keyof Pokemon): string | number => {
+    const value = pokemon[key];
+
+    if (typeof value === "number") {
+        return value;
+    }
+
+    if (typeof value === "boolean") {
+        return value ? 1 : 0;
+    }
+
+    if (value == null) {
+        return "";
+    }
+
+    if (Array.isArray(value)) {
+        return value.join(", ").toLocaleLowerCase();
+    }
+
+    if (typeof value === "object") {
+        return JSON.stringify(value).toLocaleLowerCase();
+    }
+
+    return String(value).toLocaleLowerCase();
+};
+
+export const sortPokemonForMassEditor = (
+    pokemon: Pokemon[],
+    sort?: MassEditorSort,
+) => {
+    if (sort == null) {
+        return pokemon;
+    }
+
+    const direction = sort.direction === "asc" ? 1 : -1;
+
+    return [...pokemon].sort((a, b) => {
+        const aValue = getSortValue(a, sort.key);
+        const bValue = getSortValue(b, sort.key);
+
+        if (aValue === bValue) {
+            return 0;
+        }
+
+        if (typeof aValue === "number" && typeof bValue === "number") {
+            return (aValue - bValue) * direction;
+        }
+
+        return String(aValue).localeCompare(String(bValue)) * direction;
+    });
+};
+
 const determineCell = (
     key: keyof Pokemon,
     value: unknown,
@@ -85,15 +144,56 @@ const cellRenderer: (
         );
     };
 
-export function renderColumns(pokemon, editPokemon) {
+const getNextSort = (
+    currentSort: MassEditorSort | undefined,
+    key: keyof Pokemon,
+): MassEditorSort => {
+    if (currentSort?.key !== key) {
+        return { key, direction: "asc" };
+    }
+
+    return {
+        key,
+        direction: currentSort.direction === "asc" ? "desc" : "asc",
+    };
+};
+
+export function renderColumns(
+    pokemon,
+    editPokemon,
+    sort?: MassEditorSort,
+    setSort?: React.Dispatch<React.SetStateAction<MassEditorSort | undefined>>,
+) {
     return Object.keys(PokemonKeys).map((key) => {
+        const pokemonKey = key as keyof Pokemon;
+        const isSorted = sort?.key === pokemonKey;
+
         return (
             <Column
                 key={key}
                 name={key}
+                nameRenderer={(name) => (
+                    <Button
+                        aria-label={`Sort by ${name}`}
+                        icon={
+                            isSorted
+                                ? sort.direction === "asc"
+                                    ? "sort-asc"
+                                    : "sort-desc"
+                                : "sort"
+                        }
+                        minimal
+                        small
+                        onClick={() => setSort?.((currentSort) =>
+                            getNextSort(currentSort, pokemonKey),
+                        )}
+                    >
+                        {name}
+                    </Button>
+                )}
                 cellRenderer={cellRenderer(
                     pokemon,
-                    key as keyof Pokemon,
+                    pokemonKey,
                     editPokemon,
                 )}
             />
@@ -167,16 +267,19 @@ export function MassEditorTableBase({
     pokemon,
     editPokemon,
 }: MassEditorTableProps) {
+    const [sort, setSort] = React.useState<MassEditorSort | undefined>();
+    const sortedPokemon = sortPokemonForMassEditor(pokemon, sort);
+
     return (
         <>
-            <Table numRows={pokemon.length} numFrozenColumns={2}>
-                {renderColumns(pokemon, editPokemon)}
+            <Table numRows={sortedPokemon.length} numFrozenColumns={2}>
+                {renderColumns(sortedPokemon, editPokemon, sort, setSort)}
             </Table>
             <div style={{ display: "flex", justifyContent: "space-between", paddingTop: "1rem" }}>
                 <AddPokemonButton pokemon={generateEmptyPokemon(pokemon)} />
                 <Button
                     icon="download"
-                    onClick={() => downloadCSV(pokemon)}
+                    onClick={() => downloadCSV(sortedPokemon)}
                 >
                     Download as CSV
                 </Button>

--- a/src/components/Editors/PokemonEditor/__tests__/MassEditorTable.test.ts
+++ b/src/components/Editors/PokemonEditor/__tests__/MassEditorTable.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { sortPokemonForMassEditor } from "../MassEditorTable";
+import type { Pokemon } from "models";
+import { Types } from "utils";
+
+const pokemon = [
+    {
+        id: "charlie",
+        species: "Charizard",
+        level: 36,
+        types: [Types.Fire, Types.Flying],
+    },
+    {
+        id: "bulby",
+        species: "Bulbasaur",
+        level: 5,
+        types: [Types.Grass, Types.Poison],
+    },
+    {
+        id: "squirt",
+        species: "Squirtle",
+        level: 5,
+        types: [Types.Water, Types.Water],
+    },
+] as Pokemon[];
+
+describe(sortPokemonForMassEditor.name, () => {
+    it("keeps the input order when no sort is selected", () => {
+        expect(sortPokemonForMassEditor(pokemon).map((poke) => poke.id)).toEqual([
+            "charlie",
+            "bulby",
+            "squirt",
+        ]);
+    });
+
+    it("sorts string fields ascending and descending", () => {
+        expect(
+            sortPokemonForMassEditor(pokemon, {
+                key: "species",
+                direction: "asc",
+            }).map((poke) => poke.species),
+        ).toEqual(["Bulbasaur", "Charizard", "Squirtle"]);
+
+        expect(
+            sortPokemonForMassEditor(pokemon, {
+                key: "species",
+                direction: "desc",
+            }).map((poke) => poke.species),
+        ).toEqual(["Squirtle", "Charizard", "Bulbasaur"]);
+    });
+
+    it("sorts number fields numerically", () => {
+        expect(
+            sortPokemonForMassEditor(pokemon, {
+                key: "level",
+                direction: "asc",
+            }).map((poke) => poke.id),
+        ).toEqual(["bulby", "squirt", "charlie"]);
+    });
+});


### PR DESCRIPTION
Fixes #42.

## Summary
- Adds sortable column-header buttons to the Mass Editor table.
- Sorts locally in the Mass Editor without rewriting Pokemon positions or saved order.
- Applies the selected sort order to CSV downloads from the Mass Editor.

## Validation
- npm run test:run -- src/components/Editors/PokemonEditor/__tests__/MassEditorTable.test.ts
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
- Browser smoke on http://127.0.0.1:8093 confirmed the Mass Editor opens and exposes column-header controls including `Sort by id`, `Sort by species`, and `Sort by level`.