### PR TITLE
Widen Pokemon number inputs for Firefox

### DIFF
--- a/src/components/Editors/Editor/editor.css
+++ b/src/components/Editors/Editor/editor.css
@@ -158,7 +158,15 @@ html.bp5-dark {
     padding: 0.25rem;
 }
 .current-pokemon-number {
-    width: 6rem;
+    box-sizing: border-box;
+    min-width: 7.5rem;
+    width: 7.5rem;
+}
+.current-pokemon-number input[type="number"] {
+    box-sizing: border-box;
+    min-width: 0;
+    padding-right: 1.5rem;
+    width: 100%;
 }
 .current-pokemon-checkbox {
     display: inline-flex;


### PR DESCRIPTION
Fixes #206.

## Summary
- Widens Pokemon number input wrappers so Firefox native spin controls have their own space.
- Makes number inputs use border-box sizing with right padding for the native arrows.
- Applies to both Level and Met Level number fields.

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
- Browser smoke on http://127.0.0.1:8094 measured Level and Met Level wrappers at 120px, with border-box inputs and 24px right padding for native spin controls.