### PR TITLE
Constrain ColorEdit picker on mobile

### DIFF
--- a/src/components/Common/Shared/ColorEdit.tsx
+++ b/src/components/Common/Shared/ColorEdit.tsx
@@ -74,17 +74,34 @@ export class ColorEditBase extends React.Component<
                 <Popover
                     interactionKind={PopoverInteractionKind.CLICK}
                     content={
-                        <ChromePicker
-                            color={value}
-                            onChangeComplete={(color) => {
-                                onColorChange(color);
+                        <div
+                            style={{
+                                maxWidth: "calc(100vw - 2rem)",
+                                overflowX: "auto",
                             }}
-                        />
+                        >
+                            <ChromePicker
+                                color={value}
+                                onChangeComplete={(color) => {
+                                    onColorChange(color);
+                                }}
+                            />
+                        </div>
                     }
                 >
-                    <div style={{ display: "flex", alignItems: "center" }}>
+                    <div
+                        style={{
+                            alignItems: "center",
+                            display: "flex",
+                            maxWidth: "100%",
+                            minWidth: 0,
+                        }}
+                    >
                         <input
-                            style={{ border: "none" }}
+                            style={{
+                                border: "none",
+                                minWidth: 0,
+                            }}
                             onChange={onChange}
                             type="text"
                             className={cx(

--- a/src/components/Common/Shared/__tests__/ColorEdit.test.tsx
+++ b/src/components/Common/Shared/__tests__/ColorEdit.test.tsx
@@ -70,6 +70,12 @@ describe("ColorEditBase", () => {
         expect(input.name).toBe("test-color");
     });
 
+    it("allows the text input to shrink in narrow layouts", () => {
+        render(<ColorEditBase {...defaultProps} />);
+        const input = screen.getByRole("textbox") as HTMLInputElement;
+        expect(input.style.minWidth).toBe("0");
+    });
+
     it("displays rgba format for colors with transparency", () => {
         const propsWithAlpha = {
             ...defaultProps,


### PR DESCRIPTION
Fixes #224.

## Summary
- Wraps the Chrome color picker in a viewport-constrained container.
- Enables horizontal overflow inside the picker wrapper instead of letting the page overflow on narrow screens.
- Lets the color text input shrink within narrow editor rows.

## Validation
- npm run test:run -- src/components/Common/Shared/__tests__/ColorEdit.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
- Mobile browser smoke on http://127.0.0.1:8095 at 390px viewport: opened Background color picker and measured picker wrapper at 225px wide, max-width 358px, overflow-x auto.