### PR TITLE
Add option to hide Pokemon names

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -667,6 +667,15 @@ export class StyleEditorBase extends React.Component<
 
                 <div className={styleEdit}>
                     <Checkbox
+                        checked={props.style.hidePokemonNames}
+                        name="hidePokemonNames"
+                        label="Hide Pokémon Names"
+                        onChange={(e) => editCheckboxEvent(e, props, "hidePokemonNames")}
+                    />
+                </div>
+
+                <div className={styleEdit}>
+                    <Checkbox
                         checked={props.style.minimalTeamLayout}
                         name="minimalTeamLayout"
                         label="Minimal Team Layout"

--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -318,7 +318,8 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
                                         !this.props.style.minimalChampsLayout
                                     }
                                     showNickname={
-                                        !this.props.style.minimalChampsLayout
+                                        !this.props.style.minimalChampsLayout &&
+                                        !this.props.style.hidePokemonNames
                                     }
                                     key={poke.id}
                                     {...poke}

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -7,6 +7,7 @@ import { Editor, Box, Pokemon } from "models";
 
 type ResultBaseProps = React.ComponentProps<typeof ResultBase>;
 type PokemonSpeciesProps = { species: string };
+type ChampsPokemonProps = PokemonSpeciesProps & { showNickname?: boolean };
 type PokemonProp = { pokemon: Pokemon };
 type ChildrenProps = { children?: React.ReactNode };
 
@@ -29,8 +30,13 @@ vi.mock("components/Pokemon/DeadPokemon/DeadPokemon", () => ({
 }));
 
 vi.mock("components/Pokemon/ChampsPokemon/ChampsPokemon", () => ({
-    ChampsPokemon: ({ species }: PokemonSpeciesProps) => (
-        <div data-testid={`champs-${species}`}>{species}</div>
+    ChampsPokemon: ({ species, showNickname }: ChampsPokemonProps) => (
+        <div
+            data-testid={`champs-${species}`}
+            data-show-nickname={String(showNickname)}
+        >
+            {species}
+        </div>
     ),
 }));
 
@@ -123,6 +129,36 @@ describe("<ResultBase />", () => {
         expect(screen.getByText("Boxed")).toBeTruthy();
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
+    });
+
+    it("passes hidden pokemon names through to champs pokemon", () => {
+        render(
+            <ResultBase
+                pokemon={createPokemon()}
+                game={{ name: "Red", customName: "" }}
+                trainer={{ notes: "", badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    hidePokemonNames: true,
+                    minimalChampsLayout: false,
+                }}
+                rules={[]}
+                customTypes={[]}
+            />,
+        );
+
+        expect(
+            screen
+                .getByTestId("champs-Victor")
+                .getAttribute("data-show-nickname"),
+        ).toBe("false");
     });
 });
 

--- a/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
+++ b/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
@@ -27,6 +27,7 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
         poke?.gameOfOrigin &&
         poke?.style?.displayGameOriginForBoxedAndDead &&
         poke?.style?.displayBackgroundInsteadOfBadge;
+    const showPokemonNames = !poke?.style?.hidePokemonNames;
     return (
         <div
             className={cx("boxed-pokemon-container")}
@@ -79,7 +80,8 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
                         data-testid="boxed-pokemon-name"
                         className="boxed-pokemon-name"
                     >
-                        {poke?.nickname} {GenderElement(poke?.gender)}{" "}
+                        {showPokemonNames ? `${poke?.nickname} ` : null}
+                        {GenderElement(poke?.gender)}{" "}
                         {poke?.level ? <span>lv. {poke?.level}</span> : null}
                         {poke?.style?.displayGameOriginForBoxedAndDead &&
                             !poke?.style?.displayBackgroundInsteadOfBadge &&

--- a/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
+++ b/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
@@ -18,4 +18,20 @@ describe(BoxedPokemonBase.name, () => {
             PokemonFixtures.Pikachu.nickname,
         );
     });
+
+    it("hides the pokemon name when configured", async () => {
+        // @ts-expect-error - Test props may not match full interface
+        const props: BoxedPokemonProps = {
+            ...PokemonFixtures.Pikachu,
+            level: 25,
+            style: { ...styleDefaults, hidePokemonNames: true },
+        };
+
+        render(<BoxedPokemonBase {...props} />);
+
+        await waitFor(() => screen.getByTestId("boxed-pokemon-name"));
+        const text = screen.getByTestId("boxed-pokemon-name").textContent;
+        expect(text).not.toContain(PokemonFixtures.Pikachu.nickname);
+        expect(text).toContain("lv. 25");
+    });
 });

--- a/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
+++ b/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
@@ -102,6 +102,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
         poke.gameOfOrigin &&
         poke.style.displayGameOriginForBoxedAndDead &&
         poke.style.displayBackgroundInsteadOfBadge;
+    const showPokemonNames = !poke.style.hidePokemonNames;
     const EMMA_MODE = feature.emmaMode;
 
     if (isMinimal && isCompactWithIcons) {
@@ -164,7 +165,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                         }}
                     >
                         <div>
-                            {poke.nickname} {GenderElement(poke.gender)} Levels{" "}
+                            {showPokemonNames ? `${poke.nickname} ` : null}
+                            {GenderElement(poke.gender)} Levels{" "}
                             {poke.metLevel}
                             &mdash;
                             {poke.level}
@@ -237,7 +239,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                     }}
                 >
                     <div>
-                        {poke.nickname} {GenderElement(poke.gender)} Levels{" "}
+                        {showPokemonNames ? `${poke.nickname} ` : null}
+                        {GenderElement(poke.gender)} Levels{" "}
                         {poke.metLevel}&mdash;
                         {poke.level}
                     </div>
@@ -316,7 +319,8 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
             )}
             <div className="dead-pokemon-info">
                 <div className="pokemon-d-nickname">
-                    {poke.nickname} {GenderElement(poke.gender)}
+                    {showPokemonNames ? `${poke.nickname} ` : null}
+                    {GenderElement(poke.gender)}
                 </div>
                 <div className="pokemon-levels">
                     Levels {poke.metLevel}&mdash;{poke.level}

--- a/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
+++ b/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
@@ -27,4 +27,22 @@ describe("<DeadPokemon />", () => {
             poke.causeOfDeath,
         );
     });
+
+    it("hides the pokemon name when configured", () => {
+        render(
+            <DeadPokemonBase
+                game={{ name: "Red", customName: "" }}
+                style={{ ...styleDefaults, hidePokemonNames: true }}
+                selectPokemon={vi.fn()}
+                minimal={false}
+                {...poke}
+            />,
+        );
+
+        expect(screen.queryByText(poke.nickname)).toBeNull();
+        expect(screen.getByText(/Levels 3/)).toBeTruthy();
+        expect(screen.getByTestId("cause-of-death").textContent).toContain(
+            poke.causeOfDeath,
+        );
+    });
 });

--- a/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
+++ b/src/components/Pokemon/TeamPokemon/TeamPokemon.tsx
@@ -127,6 +127,7 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
         const isCompactTheme =
             style.template === TemplateName.Compact ||
             style.template === TemplateName.CompactWithIcons;
+        const showPokemonNames = !style.hidePokemonNames;
         const getTypeOrNone = () => {
             if (pokemon) {
                 if (pokemon.types) {
@@ -186,18 +187,29 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                 >
                     <div className="pokemon-info-inner">
                         <div className="pokemon-main-info">
-                            <span
-                                style={{ margin: "0.25rem 0 0" }}
-                                className="pokemon-nickname"
-                            >
-                                {pokemon.nickname}
-                            </span>
-                            <span className="pokemon-name">
-                                {!pokemon.egg ? pokemon.species : "???"}
-                                {pokemon.item && style.itemStyle === "text"
-                                    ? ` @ ${pokemon.item}`
-                                    : null}
-                            </span>
+                            {showPokemonNames ? (
+                                <>
+                                    <span
+                                        style={{ margin: "0.25rem 0 0" }}
+                                        className="pokemon-nickname"
+                                    >
+                                        {pokemon.nickname}
+                                    </span>
+                                    <span className="pokemon-name">
+                                        {!pokemon.egg ? pokemon.species : "???"}
+                                        {pokemon.item && style.itemStyle === "text"
+                                            ? ` @ ${pokemon.item}`
+                                            : null}
+                                    </span>
+                                </>
+                            ) : null}
+                            {!showPokemonNames &&
+                            pokemon.item &&
+                            style.itemStyle === "text" ? (
+                                <span className="pokemon-name">
+                                    @ {pokemon.item}
+                                </span>
+                            ) : null}
                             {Boolean(pokemon.alpha) && (
                                 <span className="pokemon-alpha">
                                     <img
@@ -301,9 +313,10 @@ export class TeamPokemonInfo extends React.PureComponent<TeamPokemonInfoProps> {
                         ) : null}
                         {linkedPokemon && (
                             <div className="pokemon-linked">
-                                {style.linkedPokemonText}{" "}
-                                {linkedPokemon.nickname ||
-                                    linkedPokemon.species}
+                                {style.linkedPokemonText}
+                                {showPokemonNames
+                                    ? ` ${linkedPokemon.nickname || linkedPokemon.species}`
+                                    : null}
                                 <PokemonIcon {...linkedPokemon} />
                             </div>
                         )}
@@ -341,6 +354,7 @@ export function TeamPokemonBaseMinimal(
     }
 
     const poke = pokemon;
+    const showPokemonNames = !style.hidePokemonNames;
 
     return (
         <div
@@ -382,10 +396,16 @@ export function TeamPokemonBaseMinimal(
             </div>
             <div className="pokemon-info">
                 <div className="pokemon-info-inner">
-                    <span className="pokemon-nickname">{pokemon.nickname}</span>
-                    <span className="pokemon-name">
-                        {!pokemon.egg ? pokemon.species : "???"}
-                    </span>
+                    {showPokemonNames ? (
+                        <>
+                            <span className="pokemon-nickname">
+                                {pokemon.nickname}
+                            </span>
+                            <span className="pokemon-name">
+                                {!pokemon.egg ? pokemon.species : "???"}
+                            </span>
+                        </>
+                    ) : null}
                     {pokemon.level ? (
                         <span className="pokemon-level">
                             lv. {pokemon.level}

--- a/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
+++ b/src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx
@@ -145,6 +145,47 @@ describe("TeamPokemonBase", () => {
         expect(screen.getByTestId("pokemon-icon")).toBeTruthy();
     });
 
+    it("hides visible pokemon names when configured", () => {
+        render(
+            <TeamPokemonBase
+                pokemon={basePokemon}
+                linkedPokemon={{ ...basePokemon, nickname: "Partner" }}
+                style={{ ...baseStyle, hidePokemonNames: true }}
+                game={baseGame}
+                selectPokemon={vi.fn()}
+                editor={baseEditor}
+                customTypes={[]}
+            />,
+        );
+
+        expect(screen.queryByText("Bulby")).toBeNull();
+        expect(screen.queryByText("Bulbasaur")).toBeNull();
+        expect(screen.queryByText("Partner")).toBeNull();
+        expect(screen.getByText(/lv\. 10/i)).toBeTruthy();
+        expect(screen.getByText(/Linked To/i)).toBeTruthy();
+    });
+
+    it("hides visible pokemon names in minimal layout when configured", () => {
+        render(
+            <TeamPokemonBase
+                pokemon={basePokemon}
+                style={{
+                    ...baseStyle,
+                    hidePokemonNames: true,
+                    minimalTeamLayout: true,
+                }}
+                game={baseGame}
+                selectPokemon={vi.fn()}
+                editor={baseEditor}
+                customTypes={[]}
+            />,
+        );
+
+        expect(screen.queryByText("Bulby")).toBeNull();
+        expect(screen.queryByText("Bulbasaur")).toBeNull();
+        expect(screen.getByText(/lv\. 10/i)).toBeTruthy();
+    });
+
     it("renders tera and alpha indicators when provided", () => {
         render(
             <TeamPokemonBase
@@ -217,6 +258,29 @@ describe("TeamPokemonInfo", () => {
         );
 
         expect(screen.queryByTestId("moves")).toBeNull();
+    });
+
+    it("hides visible pokemon names while preserving other details", () => {
+        render(
+            <TeamPokemonInfo
+                generation={Generation.Gen3}
+                style={{
+                    ...baseStyle,
+                    hidePokemonNames: true,
+                    itemStyle: "text",
+                }}
+                pokemon={{ ...basePokemon, item: "Leftovers" }}
+                customTypes={[]}
+                linkedPokemon={undefined}
+                game={baseGame}
+            />,
+        );
+
+        expect(screen.queryByText("Bulby")).toBeNull();
+        expect(screen.queryByText("Bulbasaur")).toBeNull();
+        expect(screen.getByText(/lv\. 10/i)).toBeTruthy();
+        expect(screen.getByText("Overgrow")).toBeTruthy();
+        expect(screen.getByText("@ Leftovers")).toBeTruthy();
     });
 
     it("shows Gen 1 special stat label", () => {

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -47,6 +47,7 @@ export interface Styles {
     trainerAuto: boolean;
     scaleSprites: boolean;
     showPokemonMoves: boolean;
+    hidePokemonNames: boolean;
     spritesMode: boolean;
     teamImages: TeamImagesType;
     teamPokemonBorder: boolean;
@@ -95,6 +96,7 @@ export const styleDefaults: Styles = {
     resultWidth: "1200",
     scaleSprites: false,
     showPokemonMoves: true,
+    hidePokemonNames: false,
     spritesMode: false,
     teamImages: "standard",
     teamPokemonBorder: true,


### PR DESCRIPTION
Fixes #517.

## Summary
- Adds a `Hide Pokémon Names` style option.
- Hides visible Pokemon nickname/species text in team, boxed, dead, linked Pokemon, and champs rendering when enabled.
- Keeps non-name details visible, including levels, gender, moves, death/met details, game origin badges, and text-style held items.

## Validation
- npm run test:run -- src/components/Pokemon/TeamPokemon/__tests__/TeamPokemon.test.tsx src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx src/components/Features/Result/__tests__/Result.test.tsx
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build
- git diff --check
- Browser smoke on http://127.0.0.1:8096 confirmed the new `Hide Pokémon Names` checkbox appears in Style settings and toggles on through the UI.