### PR TITLE
Show checkpoints on dead Pokemon

### DIFF
--- a/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
+++ b/src/components/Pokemon/DeadPokemon/DeadPokemon.tsx
@@ -23,6 +23,7 @@ import {
 import { selectPokemon } from "actions";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { State } from "state";
+import { CheckpointsDisplay } from "components/Features/Result/TrainerResult";
 
 const spriteStyle = (style: Styles) => {
     if (style.spritesMode) {
@@ -98,6 +99,17 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
             editorDarkMode={poke.style.editorDarkMode}
         />
     );
+    const renderCheckpoints = () =>
+        poke.checkpoints?.length ? (
+            <div className="flex flex-wrap pokemon-checkpoints dead-pokemon-checkpoints">
+                <CheckpointsDisplay
+                    className="pokemon-checkpoint"
+                    game={poke.game}
+                    clearedCheckpoints={poke.checkpoints}
+                    style={style}
+                />
+            </div>
+        ) : null;
     const useGameOfOriginColor =
         poke.gameOfOrigin &&
         poke.style.displayGameOriginForBoxedAndDead &&
@@ -172,6 +184,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                         <div data-testid="cause-of-death">
                             {poke.causeOfDeath}
                         </div>
+                        {renderCheckpoints()}
                         {style.displayGameOriginForBoxedAndDead &&
                             !poke.style.displayBackgroundInsteadOfBadge &&
                             poke.gameOfOrigin && (
@@ -242,6 +255,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                         {poke.level}
                     </div>
                     <div data-testid="cause-of-death">{poke.causeOfDeath}</div>
+                    {renderCheckpoints()}
                     {style.displayGameOriginForBoxedAndDead &&
                         !poke.style.displayBackgroundInsteadOfBadge &&
                         poke.gameOfOrigin && (
@@ -328,6 +342,7 @@ export const DeadPokemonBase = (poke: DeadPokemonProps) => {
                 >
                     {poke.causeOfDeath}
                 </div>
+                {renderCheckpoints()}
                 {style.displayGameOriginForBoxedAndDead &&
                     !poke.style.displayBackgroundInsteadOfBadge &&
                     poke.gameOfOrigin && (

--- a/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
+++ b/src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { DeadPokemonBase } from "../DeadPokemon";
 import { generateEmptyPokemon, styleDefaults } from "utils";
 import { render, screen } from "utils/testUtils";
+import { resetCheckpoints } from "actions";
+import { store } from "store";
 
 const poke = {
     ...generateEmptyPokemon(),
@@ -13,6 +15,10 @@ const poke = {
 };
 
 describe("<DeadPokemon />", () => {
+    beforeEach(() => {
+        store.dispatch(resetCheckpoints("Red"));
+    });
+
     it("renders its content", () => {
         render(
             <DeadPokemonBase
@@ -25,6 +31,28 @@ describe("<DeadPokemon />", () => {
         );
         expect(screen.getByTestId("cause-of-death").textContent).toContain(
             poke.causeOfDeath,
+        );
+    });
+
+    it("renders checkpoint badges earned before death", () => {
+        render(
+            <DeadPokemonBase
+                game={{ name: "Red", customName: "" }}
+                style={styleDefaults}
+                selectPokemon={vi.fn()}
+                minimal={false}
+                {...poke}
+                checkpoints={[
+                    { name: "Boulder Badge", image: "boulder-badge" },
+                ]}
+            />,
+        );
+
+        expect(screen.getByAltText("Boulder Badge").className).toContain(
+            "obtained",
+        );
+        expect(screen.getByAltText("Cascade Badge").className).toContain(
+            "not-obtained",
         );
     });
 });


### PR DESCRIPTION
Fixes #536.

## Summary
- renders Pokemon checkpoint badges on dead Pokemon cards using the existing checkpoint badge display
- includes checkpoint badges for regular and minimal dead layouts
- adds a render test that verifies earned and unearned badges are classed correctly

## Validation
- `npm run test:run -- src/components/Pokemon/DeadPokemon/__tests__/DeadPokemon.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `127.0.0.1:8116` seeded a dead Pikachu with Boulder Badge, then verified the dead card, cause of death, obtained Boulder Badge, and unearned Cascade Badge rendered correctly.