### PR TITLE
Add death order sort option

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -694,6 +694,23 @@ export class StyleEditorBase extends React.Component<
 
                 <div className={styleEdit}>
                     <Checkbox
+                        checked={Boolean(
+                            props.style.sortDeadPokemonByDeathTimestamp,
+                        )}
+                        name="sortDeadPokemonByDeathTimestamp"
+                        label="Sort Dead Pokémon by Death Order"
+                        onChange={(e) =>
+                            editCheckboxEvent(
+                                e,
+                                props,
+                                "sortDeadPokemonByDeathTimestamp",
+                            )
+                        }
+                    />
+                </div>
+
+                <div className={styleEdit}>
+                    <Checkbox
                         checked={props.style.minimalChampsLayout}
                         name="minimalChampsLayout"
                         label="Minimal Champs Layout"

--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -174,6 +174,38 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         });
     }
 
+    private getDeathSortValue(poke: Pokemon) {
+        const timestamp = poke.deathTimestamp;
+        if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+            return timestamp;
+        }
+
+        if (typeof timestamp === "string") {
+            const numeric = Number(timestamp);
+            if (Number.isFinite(numeric)) return numeric;
+
+            const parsed = Date.parse(timestamp);
+            if (Number.isFinite(parsed)) return parsed;
+        }
+
+        return Number.POSITIVE_INFINITY;
+    }
+
+    private getOrderedBoxPokemon(pokemon: Pokemon[], box?: Box) {
+        if (
+            (box?.name === "Dead" || box?.inheritFrom === "Dead") &&
+            this.props.style.sortDeadPokemonByDeathTimestamp
+        ) {
+            return pokemon.slice().sort((a, b) => {
+                const deathSort =
+                    this.getDeathSortValue(a) - this.getDeathSortValue(b);
+                return deathSort || sortPokes(a, b);
+            });
+        }
+
+        return pokemon;
+    }
+
     private getCorrectStatusWrapper(
         pokes: Pokemon[],
         box,
@@ -287,7 +319,7 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
                     className="boxed-container-inner"
                     style={this.getBoxStyle(box?.name || box?.inheritFrom)}
                 >
-                    {pokemon.map((poke) => {
+                    {this.getOrderedBoxPokemon(pokemon, box).map((poke) => {
                         if (
                             box?.name === "Boxed" ||
                             box?.inheritFrom === "Boxed"

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -124,6 +124,58 @@ describe("<ResultBase />", () => {
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
     });
+
+    it("sorts dead Pokemon by death order when enabled", () => {
+        const pokemon = [
+            generateEmptyPokemon([], {
+                id: "team-1",
+                species: "Alpha",
+                status: "Team",
+            }),
+            generateEmptyPokemon([], {
+                id: "dead-late",
+                species: "Late",
+                status: "Dead",
+                deathTimestamp: 200,
+                position: 0,
+            }),
+            generateEmptyPokemon([], {
+                id: "dead-early",
+                species: "Early",
+                status: "Dead",
+                deathTimestamp: 100,
+                position: 1,
+            }),
+        ];
+
+        render(
+            <ResultBase
+                pokemon={pokemon}
+                game={{ name: "Red", customName: "" }}
+                trainer={{ notes: "", badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    sortDeadPokemonByDeathTimestamp: true,
+                    trainerSectionOrientation: "horizontal",
+                }}
+                rules={[]}
+                customTypes={[]}
+            />,
+        );
+
+        const deadPokemon = screen
+            .getAllByTestId(/^dead-/)
+            .map((node) => node.textContent);
+
+        expect(deadPokemon).toEqual(["Early", "Late"]);
+    });
 });
 
 describe("<BackspriteMontage />", () => {

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -15,7 +15,7 @@ export interface Pokemon {
     ability?: string;
     moves?: string[];
     causeOfDeath?: string;
-    deathTimestamp?: string;
+    deathTimestamp?: string | number;
     forme?: Forme;
     item?: string;
     types?: [Types, Types];

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -37,6 +37,7 @@ export interface Styles {
     minimalBoxedLayout: boolean;
     minimalTeamLayout: boolean;
     minimalDeadLayout: boolean;
+    sortDeadPokemonByDeathTimestamp: boolean;
     minimalChampsLayout: boolean;
     movesPosition: OrientationType;
     oldMetLocationFormat: boolean;
@@ -88,6 +89,7 @@ export const styleDefaults: Styles = {
     minimalBoxedLayout: false,
     minimalTeamLayout: false,
     minimalDeadLayout: false,
+    sortDeadPokemonByDeathTimestamp: false,
     minimalChampsLayout: true,
     movesPosition: "horizontal" as OrientationType,
     oldMetLocationFormat: false,


### PR DESCRIPTION
Fixes #824.

## Summary
- adds a Style editor checkbox for sorting the Dead section by death order
- sorts only Dead boxes by existing `deathTimestamp` when the option is enabled, falling back to position for ties or missing timestamps
- updates the Pokemon model to reflect the numeric `Date.now()` death timestamps already written by the reducer
- adds Result coverage for the death-order rendering behavior

## Validation
- `npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `127.0.0.1:8117` seeded two Dead Pokemon in reverse state order with the new setting enabled, then verified the rendered Dead section order was Early then Late.