### PR TITLE
Expose custom result font setting

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -266,6 +266,21 @@ export class StyleEditorBase extends React.Component<
 
                 <div className={styleEdit}>
                     <label
+                        htmlFor="font"
+                        className={cx(Classes.LABEL, Classes.INLINE)}
+                    >
+                        Font Family
+                    </label>
+                    <input
+                        value={props.style.font || ""}
+                        name="font"
+                        onChange={(e) => editEvent(e, props)}
+                        className={Classes.INPUT}
+                    />
+                </div>
+
+                <div className={styleEdit}>
+                    <label
                         htmlFor="itemStyle"
                         className={cx(Classes.LABEL, Classes.INLINE)}
                     >

--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -512,7 +512,7 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
                         style={{
                             fontFamily: style.usePokemonGBAFont
                                 ? "pokemon_font"
-                                : "inherit",
+                                : style.font || "inherit",
                             fontSize: style.usePokemonGBAFont ? "125%" : "100%",
                             margin: this.state.isDownloading
                                 ? "0"

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -274,7 +274,7 @@ export const ResultInner = React.forwardRef(
                     overflowY: "auto",
                     fontFamily: style.usePokemonGBAFont
                         ? "pokemon_font"
-                        : "inherit",
+                        : style.font || "inherit",
                     fontSize: style.usePokemonGBAFont ? "125%" : "100%",
                 }}
             >

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -124,6 +124,35 @@ describe("<ResultBase />", () => {
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
     });
+
+    it("applies the configured custom font family", () => {
+        const { container } = render(
+            <ResultBase
+                pokemon={createPokemon()}
+                game={{ name: "Red", customName: "" }}
+                trainer={{ notes: "", badges: [] }}
+                box={boxes}
+                editor={baseEditor}
+                selectPokemon={vi.fn() as unknown as ResultBaseProps["selectPokemon"]}
+                toggleMobileResultView={
+                    vi.fn() as unknown as ResultBaseProps["toggleMobileResultView"]
+                }
+                toggleDialog={vi.fn() as unknown as ResultBaseProps["toggleDialog"]}
+                style={{
+                    ...styleDefaults,
+                    font: "Papyrus",
+                    trainerSectionOrientation: "horizontal",
+                }}
+                rules={[]}
+                customTypes={[]}
+            />,
+        );
+
+        expect(
+            (container.querySelector(".result") as HTMLElement).style
+                .fontFamily,
+        ).toBe("Papyrus");
+    });
 });
 
 describe("<BackspriteMontage />", () => {


### PR DESCRIPTION
Fixes #319.

## Summary
- adds a Font Family input to the Style editor using the existing `style.font` setting
- applies `style.font` to Result and Result2 when the Pokemon GBA font option is off
- keeps the GBA font option as the explicit override when enabled
- adds Result coverage for applying the configured custom font

## Validation
- `npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `127.0.0.1:8118` seeded `style.font = Papyrus`, then verified the rendered `.result` inline font and Style editor font input both reflected `Papyrus`.