### PR TITLE
Allow custom nature text

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -713,8 +713,8 @@ export class CurrentPokemonEditBase extends React.Component<
                         inputName="nature"
                         placeholder="Sassy"
                         value={currentPokemon.nature}
-                        type="select"
-                        options={listOfNatures}
+                        type="text"
+                        items={listOfNatures}
                         pokemon={currentPokemon}
                         key={this.state.selectedId + "nature"}
                     />

--- a/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonInput.tsx
@@ -190,20 +190,31 @@ export function PokemonTextInput({
     edit,
     setEdit,
     onChange,
+    items,
 }: PokemonInputProps) {
+    const listId = items?.length ? `${inputName}-options` : undefined;
+
     return (
-        <input
-            onChange={onChange}
-            onInput={(e) => setEdit({ [inputName]: e.currentTarget.value })}
-            type={type}
-            name={inputName}
-            value={String(edit[inputName] ?? "")}
-            placeholder={placeholder}
-            disabled={disabled}
-            className={
-                disabled ? `${Classes.DISABLED} ${Classes.TEXT_MUTED}` : ""
-            }
-        />
+        <>
+            <input
+                onChange={onChange}
+                onInput={(e) => setEdit({ [inputName]: e.currentTarget.value })}
+                type={type}
+                name={inputName}
+                value={String(edit[inputName] ?? "")}
+                placeholder={placeholder}
+                disabled={disabled}
+                list={listId}
+                className={
+                    disabled ? `${Classes.DISABLED} ${Classes.TEXT_MUTED}` : ""
+                }
+            />
+            {listId ? (
+                <datalist id={listId}>
+                    {items?.map((item) => <option key={item} value={item} />)}
+                </datalist>
+            ) : null}
+        </>
     );
 }
 

--- a/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonInput.test.tsx
+++ b/src/components/Editors/PokemonEditor/__tests__/CurrentPokemonInput.test.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { render, screen } from "utils/testUtils";
+import { PokemonTextInput } from "../CurrentPokemonInput";
+
+describe("<PokemonTextInput />", () => {
+    it("renders text suggestions when items are provided", () => {
+        const { container } = render(
+            <PokemonTextInput
+                labelName="Nature"
+                inputName="nature"
+                type="text"
+                value="Brave"
+                edit={{ nature: "Brave" }}
+                setEdit={vi.fn()}
+                onChange={vi.fn()}
+                items={["Brave", "Custom"]}
+                key="nature"
+            />,
+        );
+
+        expect(screen.getByDisplayValue("Brave").getAttribute("list")).toBe(
+            "nature-options",
+        );
+        expect(
+            container.querySelector('datalist option[value="Custom"]'),
+        ).toBeDefined();
+    });
+});


### PR DESCRIPTION
Fixes #681.

## Summary
- changes the Nature editor from a closed select to a free-text field
- keeps standard nature names available through datalist suggestions
- adds coverage for text inputs with suggestions

## Validation
- `npm run test:run -- src/components/Editors/PokemonEditor/__tests__/CurrentPokemonInput.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `127.0.0.1:8119`: added a Pokémon in the live editor, verified `input[name="nature"]` uses `list="nature-options"`, confirmed the standard `Sassy` suggestion exists, entered custom value `Energetic`, and confirmed it persisted to `localStorage`.
