### PR TITLE
Normalize legacy custom move maps

### DIFF
--- a/src/components/Editors/DataEditor/DataEditor.tsx
+++ b/src/components/Editors/DataEditor/DataEditor.tsx
@@ -19,7 +19,6 @@ import { newNuzlocke, replaceState } from "actions";
 import { Badge, Game, Pokemon, Trainer } from "models";
 import { BaseEditor } from "components/Editors/BaseEditor/BaseEditor";
 import { State } from "state";
-import { noop } from "redux-saga/utils";
 import {
     gameOfOriginToColor,
     GameSaveFormat,
@@ -43,6 +42,7 @@ import SaveFileWorker from "parsers/worker?worker";
 import { cx } from "emotion";
 import { StatusDropZone } from "./StatusDropZone";
 import { serializeNuzlockeJson } from "utils/nuzlockeJson";
+import { normalizeCustomMoveMap } from "utils/normalizeCustomMoveMap";
 
 export interface DataEditorProps {
     state: State;
@@ -297,9 +297,6 @@ export class DataEditorBase extends React.Component<
     };
 
     private confirmImport = () => {
-        let cmm: { customMoveMap: State["customMoveMap"] } = {
-            customMoveMap: [],
-        };
         const override = this.state.overrideImport;
         const data = handleExceptions(JSON.parse(this.state.data));
         const nuz = this.props.state;
@@ -311,15 +308,10 @@ export class DataEditorBase extends React.Component<
             excludedAreas: [],
             customAreas: [],
         };
-        if (!Array.isArray(data.customMoveMap)) {
-            noop();
-        } else {
-            cmm = { customMoveMap: data.customMoveMap };
-        }
         this.props.replaceState({
             ...safeguards,
             ...(override ? data : nuz),
-            ...cmm,
+            customMoveMap: normalizeCustomMoveMap(data.customMoveMap),
         });
         this.props.newNuzlocke(this.state.data, { isCopy: false });
         this.writeAllData();

--- a/src/store/__tests__/persistence.test.ts
+++ b/src/store/__tests__/persistence.test.ts
@@ -104,6 +104,33 @@ describe("Zustand persistence compatibility", () => {
         unsubscribePersistence();
     });
 
+    it("drops malformed legacy custom move map entries during rehydration", () => {
+        const legacyEnvelope = JSON.stringify({
+            customMoveMap: JSON.stringify([
+                { key: 0, name: "Team" },
+                { move: "Custom Beam", type: "Electric" },
+            ]),
+            _persist: JSON.stringify({
+                version: "1.6.0",
+                rehydrated: true,
+            }),
+        });
+
+        window.localStorage.setItem(PERSIST_KEY, legacyEnvelope);
+
+        const savedState = deserializePersistedState(
+            window.localStorage.getItem(PERSIST_KEY),
+        );
+
+        expect(savedState?.customMoveMap).toEqual([
+            {
+                id: "custom-move-1",
+                move: "Custom Beam",
+                type: "Electric",
+            },
+        ]);
+    });
+
     it("dispatches through Zustand and flushes the current state back to localStorage", async () => {
         const { persistor, store, unsubscribePersistence, zustandStore } =
             createNuzlockeStore({

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -1,6 +1,7 @@
 import { version } from "../../package.json";
 import { State } from "state";
 import { styleDefaults } from "utils/styleDefaults";
+import { normalizeCustomMoveMap } from "utils/normalizeCustomMoveMap";
 
 export const PERSIST_KEY = "persist:root";
 
@@ -144,10 +145,16 @@ export const deserializePersistedState = (
             state[key] = typeof value === "string" ? JSON.parse(value) : value;
         }
 
-        return migratePersistedState(
+        const migratedState = migratePersistedState(
             state as Partial<State>,
             getPersistedVersion(envelope),
         );
+        return {
+            ...migratedState,
+            customMoveMap: normalizeCustomMoveMap(
+                migratedState.customMoveMap,
+            ),
+        };
     } catch {
         return undefined;
     }

--- a/src/utils/normalizeCustomMoveMap.ts
+++ b/src/utils/normalizeCustomMoveMap.ts
@@ -1,0 +1,37 @@
+import type { State } from "state";
+
+export const normalizeCustomMoveMap = (
+    customMoveMap: unknown,
+): State["customMoveMap"] => {
+    if (!Array.isArray(customMoveMap)) return [];
+
+    return customMoveMap.flatMap((entry, index) => {
+        if (!entry || typeof entry !== "object") return [];
+
+        const { id, move, type } = entry as {
+            id?: unknown;
+            move?: unknown;
+            type?: unknown;
+        };
+
+        if (
+            typeof move !== "string" ||
+            typeof type !== "string" ||
+            !move.trim() ||
+            !type.trim()
+        ) {
+            return [];
+        }
+
+        return [
+            {
+                id:
+                    typeof id === "string" && id.trim()
+                        ? id
+                        : `custom-move-${index}`,
+                move,
+                type,
+            },
+        ];
+    });
+};


### PR DESCRIPTION
Fixes #443.

## Summary
- normalizes custom move map data during persisted-state rehydration
- applies the same normalization when importing nuzlocke JSON saves
- drops malformed legacy entries while preserving valid custom moves with stable fallback ids
- adds regression coverage for a legacy malformed custom move map shape

## Validation
- `npm run test:run -- src/store/__tests__/persistence.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `127.0.0.1:8120`: loaded malformed legacy `customMoveMap` data, verified the Pokémon editor did not show `Something went wrong.`, opened the Move Editor, verified it still did not show an error boundary, and confirmed a valid custom move survived normalization.
