### PR TITLE
Add randomized game flag

### DIFF
--- a/src/actions/editGame.ts
+++ b/src/actions/editGame.ts
@@ -6,6 +6,8 @@ export const EDIT_GAME: EDIT_GAME = "EDIT_GAME";
 
 export interface GameType {
     name?: Game;
+    customName?: string;
+    randomized?: boolean;
 }
 
 export type editGame = (e: object) => Action<EDIT_GAME>;

--- a/src/components/Editors/GameEditor/GameEditor.tsx
+++ b/src/components/Editors/GameEditor/GameEditor.tsx
@@ -53,6 +53,10 @@ export class GameEditorBase extends React.Component<
         this.props.editGame({ customName: e.target.value });
     };
 
+    private onRandomizedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        this.props.editGame({ randomized: e.target.checked });
+    };
+
     private toggleDialog = () => this.setState({ isOpen: !this.state.isOpen });
 
     public render() {
@@ -134,6 +138,11 @@ export class GameEditorBase extends React.Component<
                             </Button>
                         )}
                     </div>
+                    <Switch
+                        label="Randomized"
+                        checked={Boolean(game.randomized)}
+                        onChange={this.onRandomizedChange}
+                    />
                 </BaseEditor>
             </>
         );

--- a/src/components/Editors/GameEditor/__tests__/GameEditor.test.tsx
+++ b/src/components/Editors/GameEditor/__tests__/GameEditor.test.tsx
@@ -41,4 +41,13 @@ describe("<GameEditor />", () => {
 
         expect(props.editGame).toHaveBeenCalledWith({ customName: "My Run" });
     });
+
+    it("updates randomized mode when toggled", () => {
+        const props = createProps();
+        render(<GameEditorBase {...props} />);
+
+        fireEvent.click(screen.getByLabelText("Randomized"));
+
+        expect(props.editGame).toHaveBeenCalledWith({ randomized: true });
+    });
 });

--- a/src/components/Features/Result/TrainerResult.tsx
+++ b/src/components/Features/Result/TrainerResult.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {
     OrientationType,
     mapTrainerImage,
-    Game,
     Styles,
     getContrastColor,
     getBadges,
@@ -21,7 +20,7 @@ export interface TrainerResultProps {
 
     checkpoints: Checkpoints;
     trainer: Trainer;
-    game: { name: Game; customName: string };
+    game: State["game"];
     style: Styles;
     rules: string[];
 }
@@ -169,6 +168,9 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
         const tciProps = { trainer, orientation };
         const enableStats = style.displayStats;
         const emmaMode = feature.emmaMode;
+        const defaultTitle = `${this.props.game.name}${
+            this.props.game.randomized ? " Randomized" : ""
+        } Nuzlocke`;
 
         return (
             <div
@@ -201,6 +203,18 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
                 >
                     {game.customName || game.name}
                 </div>
+                {game.randomized ? (
+                    <div
+                        className="game-randomized-tag"
+                        style={{
+                            ...baseDivStyle,
+                            fontWeight: "bold",
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        Randomized
+                    </div>
+                ) : null}
                 {trainer.image ? (
                     <img
                         className="trainer-image"
@@ -214,7 +228,7 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
                     </div>
                 ) : (
                     <div style={baseDivStyle} className="nuzlocke-title">
-                        {this.props.game.name} Nuzlocke
+                        {defaultTitle}
                     </div>
                 )}
                 {feature.resultv2 ? (

--- a/src/components/Features/Result/__tests__/TrainerResult.test.tsx
+++ b/src/components/Features/Result/__tests__/TrainerResult.test.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { render, screen } from "utils/testUtils";
+import { styleDefaults } from "utils";
+import { TrainerResultBase } from "../TrainerResult";
+
+describe("<TrainerResult />", () => {
+    it("labels randomized runs in the trainer section", () => {
+        render(
+            <TrainerResultBase
+                orientation="horizontal"
+                checkpoints={[]}
+                trainer={{ badges: [] }}
+                game={{ name: "White", customName: "", randomized: true }}
+                style={{ ...styleDefaults, displayBadges: false }}
+                rules={[]}
+            />,
+        );
+
+        expect(screen.getByText("Randomized")).toBeTruthy();
+        expect(screen.getByText("White Randomized Nuzlocke")).toBeTruthy();
+    });
+});

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -3,4 +3,5 @@ import { Game as GameFromUtils } from "utils";
 export interface Game {
     name: GameFromUtils;
     customName: string;
+    randomized?: boolean;
 }

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -5,6 +5,7 @@ export function game(
     state: Game = {
         name: "None",
         customName: "",
+        randomized: false,
     },
     action: Action<EDIT_GAME | REPLACE_STATE | SYNC_STATE_FROM_HISTORY>,
 ) {


### PR DESCRIPTION
Fixes #537.
Fixes #809.

## Summary
- adds a Game editor checkbox for randomized runs
- stores the randomized flag on the game state
- shows randomized runs in the result trainer section and default title
- adds editor and result coverage for the new flag

## Validation
- `npm run test:run -- src/components/Editors/GameEditor/__tests__/GameEditor.test.tsx src/components/Features/Result/__tests__/TrainerResult.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `127.0.0.1:8121`: toggled the Game editor `Randomized` checkbox, verified the result showed the `Randomized` tag, verified the default title changed to `None Randomized Nuzlocke`, and confirmed persisted game state included `randomized: true`.
