### PR TITLE
Add boxed Pokemon artwork option

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -685,6 +685,21 @@ export class StyleEditorBase extends React.Component<
 
                 <div className={styleEdit}>
                     <Checkbox
+                        checked={props.style.useArtworkForBoxedPokemon}
+                        name="useArtworkForBoxedPokemon"
+                        label="Use Artwork for Boxed Pokémon"
+                        onChange={(e) =>
+                            editCheckboxEvent(
+                                e,
+                                props,
+                                "useArtworkForBoxedPokemon",
+                            )
+                        }
+                    />
+                </div>
+
+                <div className={styleEdit}>
+                    <Checkbox
                         checked={props.style.minimalDeadLayout}
                         name="minimalDeadLayout"
                         label="Minimal Dead Layout"

--- a/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
+++ b/src/components/Pokemon/BoxedPokemon/BoxedPokemon.tsx
@@ -8,9 +8,12 @@ import { getContrastColor, Styles, gameOfOriginToColor } from "utils";
 import { PokemonIcon } from "components/Pokemon/PokemonIcon/PokemonIcon";
 import { GenderElement } from "components/Common/Shared";
 import { State } from "state";
+import { PokemonImage } from "components/Common/Shared/PokemonImage";
 
 export type BoxedPokemonProps = Pokemon & { selectPokemon: selectPokemon } & {
     style: Styles;
+    editor: State["editor"];
+    game: State["game"];
 };
 
 const getAccentColor = (prop: BoxedPokemonProps) =>
@@ -23,6 +26,8 @@ const determineWidth = (isMinimal, numerator): string => {
 // @TODO: fix this messy prop soup
 export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
     const isMinimal = poke?.style?.minimalBoxedLayout;
+    const imageBorderRadius =
+        poke?.style?.imageStyle === "round" ? "50%" : "4px";
     const useGameOfOriginColor =
         poke?.gameOfOrigin &&
         poke?.style?.displayGameOriginForBoxedAndDead &&
@@ -52,17 +57,46 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
                 // Its dependent on the way react-dnd is wired
                 // which needs to be updated to v11 anyhow
             }
-            <PokemonIcon
-                position={poke?.position}
-                species={poke?.species}
-                id={poke?.id}
-                forme={poke?.forme}
-                shiny={poke?.shiny}
-                gender={poke?.gender}
-                egg={poke?.egg}
-                customIcon={poke?.customIcon}
-                className={"boxed-pokemon-icon"}
-            />
+            {poke?.style?.useArtworkForBoxedPokemon ? (
+                <PokemonImage
+                    customImage={poke?.customImage}
+                    forme={poke?.forme}
+                    species={poke?.species}
+                    shiny={poke?.shiny}
+                    gender={poke?.gender}
+                    egg={poke?.egg}
+                    style={poke?.style}
+                    editor={poke?.editor}
+                    name={poke?.game?.name}
+                >
+                    {(image) => (
+                        <img
+                            alt={`${poke?.species || "Pokemon"} artwork`}
+                            className="boxed-pokemon-icon boxed-pokemon-art"
+                            data-testid="boxed-pokemon-art"
+                            src={image}
+                            style={{
+                                borderRadius: imageBorderRadius,
+                                height: "3rem",
+                                objectFit: "cover",
+                                width: "3rem",
+                            }}
+                        />
+                    )}
+                </PokemonImage>
+            ) : (
+                <PokemonIcon
+                    position={poke?.position}
+                    species={poke?.species}
+                    id={poke?.id}
+                    forme={poke?.forme}
+                    shiny={poke?.shiny}
+                    gender={poke?.gender}
+                    egg={poke?.egg}
+                    customIcon={poke?.customIcon}
+                    className={"boxed-pokemon-icon"}
+                />
+            )}
             {isMinimal ? null : (
                 <div
                     className="boxed-pokemon-info"
@@ -112,7 +146,11 @@ export const BoxedPokemonBase = (poke: BoxedPokemonProps) => {
 };
 
 export const BoxedPokemon = connect(
-    (state: Pick<State, keyof State>) => ({ style: state.style }),
+    (state: Pick<State, keyof State>) => ({
+        editor: state.editor,
+        game: state.game,
+        style: state.style,
+    }),
     {
         selectPokemon,
     },

--- a/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
+++ b/src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx
@@ -3,6 +3,15 @@ import { BoxedPokemonBase, BoxedPokemonProps } from "../BoxedPokemon";
 import { render, screen, waitFor } from "utils/testUtils";
 import { PokemonFixtures } from "utils/fixtures";
 import { styleDefaults } from "utils";
+
+vi.mock("components/Common/Shared/PokemonImage", () => ({
+    PokemonImage: ({
+        children,
+    }: {
+        children: (image: string) => React.ReactNode;
+    }) => <>{children("https://img.test/pikachu.png")}</>,
+}));
+
 describe(BoxedPokemonBase.name, () => {
     it("renders a Boxed Pokemon", async () => {
         // @ts-expect-error - Test props may not match full interface
@@ -16,6 +25,26 @@ describe(BoxedPokemonBase.name, () => {
         await waitFor(() => screen.getByTestId("boxed-pokemon-name"));
         expect(screen.getByTestId("boxed-pokemon-name").textContent).toContain(
             PokemonFixtures.Pikachu.nickname,
+        );
+    });
+
+    it("renders artwork when boxed artwork is enabled", async () => {
+        const props: BoxedPokemonProps = {
+            ...PokemonFixtures.Pikachu,
+            editor: { minimized: false },
+            game: { name: "Red", customName: "" },
+            selectPokemon: vi.fn(),
+            style: {
+                ...styleDefaults,
+                useArtworkForBoxedPokemon: true,
+            },
+        };
+
+        render(<BoxedPokemonBase {...props} />);
+
+        await waitFor(() => screen.getByTestId("boxed-pokemon-art"));
+        expect(screen.getByTestId("boxed-pokemon-art").getAttribute("src")).toBe(
+            "https://img.test/pikachu.png",
         );
     });
 });

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -34,6 +34,7 @@ export interface Styles {
     itemStyle: ItemStyle;
     pokeballStyle: ItemStyle;
     grayScaleDeadPokemon: boolean;
+    useArtworkForBoxedPokemon: boolean;
     minimalBoxedLayout: boolean;
     minimalTeamLayout: boolean;
     minimalDeadLayout: boolean;
@@ -85,6 +86,7 @@ export const styleDefaults: Styles = {
     pokeballStyle: "outer glow",
     iconRendering: "auto",
     grayScaleDeadPokemon: false,
+    useArtworkForBoxedPokemon: false,
     minimalBoxedLayout: false,
     minimalTeamLayout: false,
     minimalDeadLayout: false,


### PR DESCRIPTION
Fixes #745.

## Summary
- adds a Style editor checkbox to use artwork for boxed Pokémon
- keeps boxed Pokémon icons as the default behavior
- renders boxed artwork through the existing PokemonImage path when enabled
- adds coverage for boxed artwork rendering

## Validation
- `npm run test:run -- src/components/Pokemon/BoxedPokemon/__tests__/BoxedPokemon.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `127.0.0.1:8122`: added a Pokémon, changed it to Boxed, enabled `Use Artwork for Boxed Pokémon`, verified the result rendered `.boxed-pokemon-art`, verified the old boxed icon path was absent for that card, and confirmed the style flag persisted.
