### PR TITLE
Add highlight moments section

### DIFF
--- a/src/components/Editors/StyleEditor/StyleEditor.tsx
+++ b/src/components/Editors/StyleEditor/StyleEditor.tsx
@@ -721,6 +721,15 @@ export class StyleEditorBase extends React.Component<
 
                 <div className={styleEdit}>
                     <Checkbox
+                        checked={props.style.displayHighlightMoments}
+                        name="displayHighlightMoments"
+                        label="Display Highlight Moments"
+                        onChange={(e) => editCheckboxEvent(e, props, "displayHighlightMoments")}
+                    />
+                </div>
+
+                <div className={styleEdit}>
+                    <Checkbox
                         checked={props.style.displayStats}
                         name="displayStats"
                         label="Display Stats"

--- a/src/components/Features/Result/Result.css
+++ b/src/components/Features/Result/Result.css
@@ -35,6 +35,35 @@
     font-size: 1.25rem;
     font-weight: bold;
 }
+.highlight-moments-container {
+    margin: 0.75rem auto;
+    max-width: 80%;
+}
+.highlight-moments-list {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    list-style-position: inside;
+    margin: 0;
+    padding: 0;
+}
+.highlight-moment {
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 4px;
+    padding: 0.5rem 0.75rem;
+}
+.highlight-moment-pokemon,
+.highlight-moment-mvp {
+    font-weight: bold;
+}
+.highlight-moment-mvp {
+    color: #f4d35e;
+}
+.highlight-moment-note {
+    margin: 0.25rem 0 0;
+    white-space: pre-wrap;
+}
 .ng-container {
     padding-bottom: 1rem;
     background-color: #383840;
@@ -462,4 +491,3 @@
 .pokemon-checkpoint.obtained {
     display: flex;
 }
-

--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -155,6 +155,67 @@ export function BackspriteMontage({ pokemon }: { pokemon: Pokemon[] }) {
     );
 }
 
+const getPokemonDisplayName = (pokemon: Pokemon) =>
+    pokemon.nickname?.trim() || pokemon.species;
+
+export const HighlightMoments = ({
+    pokemon,
+    color,
+    style,
+}: {
+    pokemon: Pokemon[];
+    color: string;
+    style: React.CSSProperties;
+}) => {
+    const highlights = pokemon.filter(
+        (poke) => poke.mvp || Boolean(poke.notes?.trim()),
+    );
+
+    if (!highlights.length) return null;
+
+    return (
+        <div
+            className="highlight-moments-container"
+            style={{ ...style, color }}
+        >
+            <h3 style={{ color }}>Highlight Moments</h3>
+            <ol className="highlight-moments-list">
+                {highlights.map((poke) => {
+                    const note = poke.notes?.trim();
+                    return (
+                        <li key={poke.id} className="highlight-moment">
+                            <span className="highlight-moment-pokemon">
+                                {getPokemonDisplayName(poke)}
+                            </span>
+                            {poke.nickname?.trim() ? (
+                                <span className="highlight-moment-species">
+                                    {" "}
+                                    ({poke.species})
+                                </span>
+                            ) : null}
+                            {poke.status ? (
+                                <span className="highlight-moment-status">
+                                    {" "}
+                                    - {poke.status}
+                                </span>
+                            ) : null}
+                            {poke.mvp ? (
+                                <span className="highlight-moment-mvp">
+                                    {" "}
+                                    MVP
+                                </span>
+                            ) : null}
+                            {note ? (
+                                <p className="highlight-moment-note">{note}</p>
+                            ) : null}
+                        </li>
+                    );
+                })}
+            </ol>
+        </div>
+    );
+};
+
 export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
     public resultRef: React.RefObject<HTMLDivElement>;
     public constructor(props: ResultProps) {
@@ -585,6 +646,13 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
                             ? rulesContainer
                             : null}
                         {teamContainer}
+                        {style.displayHighlightMoments ? (
+                            <HighlightMoments
+                                pokemon={pokemonWithId}
+                                color={getContrastColor(bgColor)}
+                                style={paddingForVerticalTrainerSection}
+                            />
+                        ) : null}
                         {style.template === "Generations" &&
                         trainerSectionOrientation === "vertical" ? (
                             <div className="statuses-wrapper">

--- a/src/components/Features/Result/__tests__/Result.test.tsx
+++ b/src/components/Features/Result/__tests__/Result.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 
-import { ResultBase, BackspriteMontage } from "../Result";
+import { ResultBase, BackspriteMontage, HighlightMoments } from "../Result";
 import { styleDefaults, generateEmptyPokemon } from "utils";
 import { Editor, Box, Pokemon } from "models";
 
@@ -123,6 +123,57 @@ describe("<ResultBase />", () => {
         expect(screen.getByText("Boxed")).toBeTruthy();
         expect(screen.getByText(/Dead/)).toBeTruthy();
         expect(screen.getByText(/Champs/)).toBeTruthy();
+    });
+});
+
+describe("<HighlightMoments />", () => {
+    it("renders MVP and note-backed Pokémon highlights", () => {
+        const pokemon = [
+            generateEmptyPokemon([], {
+                id: "1",
+                species: "Donphan",
+                nickname: "Pachy",
+                status: "Dead",
+                mvp: true,
+                notes: "Survived two league hits.",
+            }),
+            generateEmptyPokemon([], {
+                id: "2",
+                species: "Garchomp",
+                status: "Team",
+                mvp: true,
+            }),
+            generateEmptyPokemon([], {
+                id: "3",
+                species: "Starmie",
+                status: "Champs",
+            }),
+        ];
+
+        render(<HighlightMoments pokemon={pokemon} color="#eee" style={{}} />);
+
+        expect(screen.getByText("Highlight Moments")).toBeTruthy();
+        expect(screen.getByText("Pachy")).toBeTruthy();
+        expect(screen.getByText("Survived two league hits.")).toBeTruthy();
+        expect(screen.getByText("Garchomp")).toBeTruthy();
+        expect(screen.queryByText("Starmie")).toBeNull();
+        expect(screen.getAllByText(/MVP/)).toHaveLength(2);
+    });
+
+    it("does not render when there are no highlights", () => {
+        const pokemon = [
+            generateEmptyPokemon([], {
+                id: "1",
+                species: "Starmie",
+                status: "Champs",
+            }),
+        ];
+
+        const { container } = render(
+            <HighlightMoments pokemon={pokemon} color="#eee" style={{}} />,
+        );
+
+        expect(container.firstChild).toBeNull();
     });
 });
 

--- a/src/components/Features/Result/themes.css
+++ b/src/components/Features/Result/themes.css
@@ -34,6 +34,10 @@
 .default-light .result-notes {
     color: #111;
 }
+.default-light .highlight-moment {
+    background: rgba(0, 0, 0, 0.06);
+    border-color: rgba(0, 0, 0, 0.16);
+}
 .default-light .ng-container {
     background-color: #eee;
 }

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -25,6 +25,7 @@ export interface Styles {
     customCSS: string;
     displayBadges: boolean;
     displayRules: boolean;
+    displayHighlightMoments: boolean;
     editorDarkMode: boolean;
     font: string;
     usePokemonGBAFont: boolean;
@@ -77,6 +78,7 @@ export const styleDefaults: Styles = {
     customCSS: "",
     displayBadges: true,
     displayRules: false,
+    displayHighlightMoments: false,
     editorDarkMode: false,
     font: "Open Sans",
     iconsNextToTeamPokemon: false,


### PR DESCRIPTION
## Summary
- adds a Style toggle for displaying Highlight Moments on the result
- builds the section from existing Pokemon MVP flags and non-empty notes
- styles highlight entries for dark/default-light results and preserves note line breaks

Fixes #641

## Validation
- npm run test:run -- src/components/Features/Result/__tests__/Result.test.tsx
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8123: seeded MVP/notes data, verified the section is hidden until Display Highlight Moments is enabled, confirmed the toggle persisted, and confirmed only the highlighted Pokemon rendered.