### PR TITLE
Deduplicate Gen 1 save import IDs

### DIFF
--- a/src/parsers/__tests__/gen1.test.ts
+++ b/src/parsers/__tests__/gen1.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { Gen1PokemonObject, transformPokemon } from "../gen1";
+
+const duplicateIvPokemon: Gen1PokemonObject = {
+    entriesUsed: 2,
+    speciesList: ["Beedrill", "Beedrill"],
+    pokemonList: [
+        {
+            species: "Beedrill",
+            level: 65,
+            type1: "Bug",
+            type2: "Poison",
+            moves: ["Twineedle"],
+            id: "4242",
+        },
+        {
+            species: "Beedrill",
+            level: 18,
+            type1: "Bug",
+            type2: "Poison",
+            moves: ["Fury Attack"],
+            id: "4242",
+        },
+    ],
+    pokemonNames: ["Buzz", "Buzz Jr"],
+};
+
+describe("Gen 1 parser Pokemon IDs", () => {
+    it("deduplicates repeated IV-derived IDs in one imported list", () => {
+        const pokemon = transformPokemon(duplicateIvPokemon, "Team");
+
+        expect(pokemon.map((poke) => poke.id)).toEqual([
+            "4242-sav",
+            "4242-sav-1",
+        ]);
+    });
+
+    it("keeps IDs unique across party and box imports", () => {
+        const idTracker = new Map<string, number>();
+        const partyPokemon = transformPokemon(
+            {
+                ...duplicateIvPokemon,
+                pokemonList: [duplicateIvPokemon.pokemonList[0]],
+                pokemonNames: [duplicateIvPokemon.pokemonNames[0]],
+            },
+            "Team",
+            1,
+            idTracker,
+        );
+        const boxedPokemon = transformPokemon(
+            {
+                ...duplicateIvPokemon,
+                pokemonList: [duplicateIvPokemon.pokemonList[1]],
+                pokemonNames: [duplicateIvPokemon.pokemonNames[1]],
+            },
+            "Boxed",
+            2,
+            idTracker,
+        );
+
+        expect([...partyPokemon, ...boxedPokemon].map((poke) => poke.id)).toEqual([
+            "4242-sav",
+            "4242-sav-1",
+        ]);
+    });
+});

--- a/src/parsers/gen1.ts
+++ b/src/parsers/gen1.ts
@@ -237,10 +237,22 @@ const parseBoxedPokemon = (buf: Buffer): Gen1PokemonObject => {
     };
 };
 
-const transformPokemon = (
+const getUniqueSavePokemonId = (
+    baseId: string,
+    idTracker: Map<string, number>,
+) => {
+    const id = `${baseId}-sav`;
+    const currentCount = idTracker.get(id) || 0;
+    idTracker.set(id, currentCount + 1);
+
+    return currentCount > 0 ? `${id}-${currentCount}` : id;
+};
+
+export const transformPokemon = (
     pokemonObject: Gen1PokemonObject,
     status: string,
     boxIndex = 1,
+    idTracker = new Map<string, number>(),
 ) => {
     return pokemonObject.pokemonList
         .map((poke, index) => {
@@ -252,7 +264,7 @@ const transformPokemon = (
                 types: [poke.type1, poke.type2],
                 moves: poke.moves,
                 nickname: pokemonObject.pokemonNames[index],
-                id: `${poke.id}-sav`,
+                id: getUniqueSavePokemonId(poke.id, idTracker),
                 extraData: poke.extraData,
             };
         })
@@ -303,11 +315,14 @@ export const parseGen1Save = async (file: Buffer, options: ParserOptions) => {
             .join(""),
     );
 
+    const idTracker = new Map<string, number>();
+    const partyPokemon = transformPokemon(pokemonParty, "Team", 1, idTracker);
     const pokemonFromBoxes = BOX_OFFSETS.map((box, boxIndex) => {
         return transformPokemon(
             parseBoxedPokemon(file.slice(box, box + 0x462)),
             options.boxMappings[boxIndex]["status"],
             boxIndex + 1,
+            idTracker,
         );
     }).flat();
 
@@ -339,7 +354,7 @@ export const parseGen1Save = async (file: Buffer, options: ParserOptions) => {
             badges: badges,
         },
         pokemon: [
-            ...transformPokemon(pokemonParty, "Team"),
+            ...partyPokemon,
             ...pokemonFromBoxes,
         ],
     };


### PR DESCRIPTION
## Summary
- keeps Gen 1 imported Pokemon IDs unique when the same IV-derived ID appears multiple times
- shares the ID tracker across party and PC box imports so party/box duplicates cannot overwrite each other
- adds Gen 1 parser regression coverage for repeated Beedrill-style IDs

Fixes #924

## Validation
- npm run test:run -- src/parsers/__tests__/gen1.test.ts
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build