### PR TITLE
Add level cap stats check

### DIFF
--- a/src/components/Editors/StatsEditor/StatsEditor.tsx
+++ b/src/components/Editors/StatsEditor/StatsEditor.tsx
@@ -40,6 +40,18 @@ export class StatsEditorBase extends React.Component<StatsEditorProps> {
         });
     };
 
+    private onStatsOptionValueChange = (
+        e: React.ChangeEvent<HTMLInputElement>,
+    ) => {
+        const stats = this.props.style?.statsOptions;
+        this.props.editStyle({
+            statsOptions: {
+                ...stats,
+                [e.currentTarget.name]: e.currentTarget.value,
+            },
+        });
+    };
+
     private onChange =
         (stat: State["stats"][number], use: "key" | "value") =>
         (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -96,6 +108,37 @@ export class StatsEditorBase extends React.Component<StatsEditorProps> {
                                 name="averageLevelDetailed"
                                 label="Average Level (Detailed)"
                                 onChange={this.onStatsOptionChange}
+                            />
+                        </li>
+
+                        <li
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                            }}
+                        >
+                            <Switch
+                                checked={stats?.levelCap}
+                                name="levelCap"
+                                label="Level Cap"
+                                onChange={this.onStatsOptionChange}
+                            />
+                            <input
+                                aria-label="Level Cap Value"
+                                className={cx(Classes.INPUT, "small-input")}
+                                disabled={!stats?.levelCap}
+                                min="1"
+                                name="levelCapValue"
+                                onChange={this.onStatsOptionValueChange}
+                                placeholder="cap"
+                                style={{
+                                    marginBottom: "10px",
+                                    marginLeft: "8px",
+                                    opacity: stats?.levelCap ? 1 : 0.3,
+                                    width: "5rem",
+                                }}
+                                type="number"
+                                value={stats?.levelCapValue ?? ""}
                             />
                         </li>
 

--- a/src/components/Features/Result/Stats.tsx
+++ b/src/components/Features/Result/Stats.tsx
@@ -153,6 +153,58 @@ export class StatsBase extends React.Component<
         );
     }
 
+    private getLevelCapValue() {
+        const value = Number.parseInt(
+            this.props.style.statsOptions.levelCapValue,
+            10,
+        );
+        return Number.isFinite(value) && value > 0 ? value : undefined;
+    }
+
+    private getPokemonOverLevelCap() {
+        const levelCap = this.getLevelCapValue();
+        if (!levelCap) return [];
+
+        return this.props.pokemon
+            .filter((poke) => !poke.hidden && poke.status !== "Dead")
+            .map((poke) => ({
+                ...poke,
+                parsedLevel: Number.parseInt(
+                    poke.level as unknown as string,
+                    10,
+                ),
+            }))
+            .filter(
+                (poke) =>
+                    Number.isFinite(poke.parsedLevel) &&
+                    poke.parsedLevel > levelCap,
+            );
+    }
+
+    private getLevelCapComponent() {
+        const levelCap = this.getLevelCapValue();
+        if (!levelCap) {
+            return <div>Level Cap: Not Set</div>;
+        }
+
+        const pokemonOverCap = this.getPokemonOverLevelCap();
+        const overCapText = pokemonOverCap.length
+            ? pokemonOverCap
+                  .map((poke) => {
+                      const name = poke.nickname?.trim() || poke.species;
+                      return `${name} (${poke.parsedLevel})`;
+                  })
+                  .join(", ")
+            : "None";
+
+        return (
+            <div>
+                <div>Level Cap: {levelCap}</div>
+                <div>Over Level Cap: {overCapText}</div>
+            </div>
+        );
+    }
+
     private getShinies() {
         if (!this.numberOfShinies) {
             return "None";
@@ -208,6 +260,9 @@ export class StatsBase extends React.Component<
                     {this.props.pokemon.length &&
                     style.statsOptions.averageLevelDetailed
                         ? this.getAverageLevelDetailedComponent()
+                        : null}
+                    {style.statsOptions.levelCap
+                        ? this.getLevelCapComponent()
                         : null}
                     {style.statsOptions.mostCommonKillers ? (
                         <div>

--- a/src/components/Features/Result/__tests__/Stats.test.tsx
+++ b/src/components/Features/Result/__tests__/Stats.test.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { StatsBase } from "../Stats";
+import { generateEmptyPokemon, styleDefaults } from "utils";
+
+vi.mock("components/Pokemon/PokemonIcon/PokemonIcon", () => ({
+    PokemonIcon: ({ species }: { species: string }) => (
+        <span data-testid="pokemon-icon">{species}</span>
+    ),
+}));
+
+const box = [
+    { id: 0, position: 0, name: "Team" },
+    { id: 1, position: 1, name: "Boxed" },
+    { id: 2, position: 2, name: "Dead" },
+    { id: 3, position: 3, name: "Champs" },
+];
+
+describe("<StatsBase /> level cap", () => {
+    it("lists non-hidden living Pokemon above the configured level cap", () => {
+        render(
+            <StatsBase
+                box={box}
+                color="#eee"
+                pokemon={[
+                    generateEmptyPokemon([], {
+                        id: "1",
+                        species: "Pikachu",
+                        nickname: "Pika",
+                        level: 13,
+                        status: "Team",
+                    }),
+                    generateEmptyPokemon([], {
+                        id: "2",
+                        species: "Pidgey",
+                        level: 5,
+                        status: "Team",
+                    }),
+                    generateEmptyPokemon([], {
+                        id: "3",
+                        species: "Butterfree",
+                        level: 20,
+                        status: "Boxed",
+                    }),
+                    generateEmptyPokemon([], {
+                        id: "4",
+                        species: "Raticate",
+                        level: 30,
+                        status: "Dead",
+                    }),
+                    generateEmptyPokemon([], {
+                        id: "5",
+                        species: "Mew",
+                        level: 100,
+                        hidden: true,
+                        status: "Team",
+                    }),
+                ]}
+                stats={[]}
+                style={{
+                    ...styleDefaults,
+                    statsOptions: {
+                        ...styleDefaults.statsOptions,
+                        levelCap: true,
+                        levelCapValue: "12",
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByText("Level Cap: 12")).toBeTruthy();
+        expect(
+            screen.getByText("Over Level Cap: Pika (13), Butterfree (20)"),
+        ).toBeTruthy();
+        expect(screen.queryByText(/Raticate/)).toBeNull();
+        expect(screen.queryByText(/Mew/)).toBeNull();
+    });
+
+    it("shows no over-level Pokemon when the team is within the cap", () => {
+        render(
+            <StatsBase
+                box={box}
+                pokemon={[
+                    generateEmptyPokemon([], {
+                        id: "1",
+                        species: "Pidgey",
+                        level: 5,
+                        status: "Team",
+                    }),
+                ]}
+                stats={[]}
+                style={{
+                    ...styleDefaults,
+                    statsOptions: {
+                        ...styleDefaults.statsOptions,
+                        levelCap: true,
+                        levelCapValue: "12",
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByText("Over Level Cap: None")).toBeTruthy();
+    });
+
+    it("renders a not-set message for invalid level caps", () => {
+        render(
+            <StatsBase
+                box={box}
+                pokemon={[]}
+                stats={[]}
+                style={{
+                    ...styleDefaults,
+                    statsOptions: {
+                        ...styleDefaults.statsOptions,
+                        levelCap: true,
+                        levelCapValue: "",
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByText("Level Cap: Not Set")).toBeTruthy();
+    });
+});

--- a/src/utils/styleDefaults.ts
+++ b/src/utils/styleDefaults.ts
@@ -13,6 +13,8 @@ export type ItemStyle = "outer glow" | "round" | "square" | "text";
 export interface StatsOptions {
     averageLevel: boolean;
     averageLevelDetailed: boolean;
+    levelCap: boolean;
+    levelCapValue: string;
     mostCommonKillers: boolean;
     mostCommonTypes: boolean;
     shiniesCaught: boolean;
@@ -119,6 +121,8 @@ export const styleDefaults: Styles = {
     statsOptions: {
         averageLevel: false,
         averageLevelDetailed: false,
+        levelCap: false,
+        levelCapValue: "",
         mostCommonKillers: false,
         mostCommonTypes: false,
         shiniesCaught: false,


### PR DESCRIPTION
## Summary
- adds a Stats option for Level Cap with a numeric cap input
- renders the configured level cap on the result and lists non-hidden living Pokemon above the cap
- adds focused result tests for over-cap, in-cap, hidden, and dead Pokemon behavior

Fixes #657

## Validation
- npm run test:run -- src/components/Features/Result/__tests__/Stats.test.tsx
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8124: seeded a Yellow run, enabled Display Stats and Level Cap, entered cap 12, confirmed persisted style settings and result text `Level Cap: 12` / `Over Level Cap: Pika (13)`. 