### PR TITLE
Add monolocke type markers for champs

### DIFF
--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -499,6 +499,14 @@ export class CurrentPokemonEditBase extends React.Component<
                         options={this.getTypes(false)}
                         key={this.state.selectedId + "teraType"}
                     />
+                    <CurrentPokemonInput
+                        labelName="Monolocke Type"
+                        inputName="monolockeType"
+                        value={currentPokemon.monolockeType}
+                        type="select"
+                        options={this.getTypes(false)}
+                        key={this.state.selectedId + "monolockeType"}
+                    />
                 </CurrentPokemonLayoutItem>
                 <CurrentPokemonLayoutItem>
                     <CurrentPokemonInput

--- a/src/components/Pokemon/ChampsPokemon/ChampsPokemon.tsx
+++ b/src/components/Pokemon/ChampsPokemon/ChampsPokemon.tsx
@@ -11,6 +11,7 @@ import {
     getContrastColor,
     gameOfOriginToColor,
     styleDefaults,
+    Types,
 } from "utils";
 import { Pokemon } from "models";
 import { GenderElement } from "components/Common/Shared";
@@ -63,11 +64,18 @@ export class ChampsPokemon extends React.Component<ChampsPokemonProps> {
         const base = 48;
         return (
             base +
+            (this.hasMonolockeType() ? 24 : 0) +
             (this.props.showGender ? 24 : 0) +
             (this.props.showNickname ? 128 : 0) +
             (this.props.showLevel ? 24 : 0)
         );
     };
+
+    private hasMonolockeType = () =>
+        Boolean(
+            this.props.monolockeType &&
+                this.props.monolockeType !== ("None" as Types),
+        );
 
     private getPokemonImage() {
         const {
@@ -158,6 +166,15 @@ export class ChampsPokemon extends React.Component<ChampsPokemonProps> {
                     >
                         {this.props.showNickname && this.props.nickname}
                     </span>
+                    {this.hasMonolockeType() && (
+                        <span className="champs-pokemon-monolocke-type">
+                            <img
+                                alt={`Monolocke: ${this.props.monolockeType}`}
+                                style={{ height: "1rem", margin: "0 2px" }}
+                                src={`icons/tera/${this.props.monolockeType?.toLowerCase()}.png`}
+                            />
+                        </span>
+                    )}
                     {this.props.showGender && GenderElement(this.props.gender)}
                     <span
                         className="champs-pokemon-level"

--- a/src/components/Pokemon/ChampsPokemon/__tests__/ChampsPokemon.test.tsx
+++ b/src/components/Pokemon/ChampsPokemon/__tests__/ChampsPokemon.test.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { vi } from "vitest";
+import { render, screen } from "utils/testUtils";
+import { Types } from "utils";
+import { ChampsPokemon } from "../ChampsPokemon";
+
+vi.mock("components/Pokemon/PokemonIcon/PokemonIcon", () => ({
+    PokemonIcon: (props: { className?: string }) => (
+        <div data-testid="pokemon-icon" className={props.className} />
+    ),
+}));
+
+describe("ChampsPokemon", () => {
+    it("renders the monolocke type icon when one is selected", () => {
+        render(
+            <ChampsPokemon
+                id="champ-1"
+                species="Charizard"
+                monolockeType={Types.Fire}
+                gameOfOrigin="Red"
+            />,
+        );
+
+        const icon = screen.getByAltText("Monolocke: Fire");
+        expect(icon).toBeTruthy();
+        expect(icon.getAttribute("src")).toBe("icons/tera/fire.png");
+    });
+
+    it("omits the monolocke type icon when it is not set", () => {
+        render(
+            <ChampsPokemon
+                id="champ-1"
+                species="Charizard"
+                monolockeType={"None" as Types}
+                gameOfOrigin="Red"
+            />,
+        );
+
+        expect(screen.queryByAltText(/Monolocke:/)).toBeNull();
+    });
+});

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -20,6 +20,7 @@ export interface Pokemon {
     item?: string;
     types?: [Types, Types];
     teraType?: Types;
+    monolockeType?: Types;
     customImage?: string;
     customIcon?: string;
     customItemImage?: string;
@@ -62,6 +63,7 @@ export const PokemonKeys: Pokemon = {
     item: "",
     types: [Types.Normal, Types.Normal],
     teraType: Types.Normal,
+    monolockeType: "None" as Types,
     customImage: "",
     customIcon: "",
     customItemImage: "",


### PR DESCRIPTION
## Summary
- adds a per-Pokemon Monolocke Type select in the Pokemon editor More section
- renders selected monolocke type icons on Champs Pokemon using the existing tera type icon assets
- adds focused ChampsPokemon tests for selected and unset monolocke types

Fixes #949

## Validation
- npm run test:run -- src/components/Pokemon/ChampsPokemon/__tests__/ChampsPokemon.test.tsx
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8125: seeded a Champs Charizard with monolockeType Fire, opened Pokemon > More, confirmed Monolocke Type selected Fire, and confirmed the result Champs entry rendered an icon with alt Monolocke: Fire and src icons/tera/fire.png.