### PR TITLE
Add copy actions for save boxes and Pokemon

### DIFF
--- a/src/components/Editors/SavesEditor/NuzlockeSave.tsx
+++ b/src/components/Editors/SavesEditor/NuzlockeSave.tsx
@@ -17,6 +17,7 @@ import {
     switchNuzlocke,
     replaceState,
     updateSwitchNuzlocke,
+    selectPokemon,
 } from "actions";
 import {
     feature,
@@ -31,6 +32,7 @@ import { DeleteAlert } from "components/Editors/DataEditor/DeleteAlert";
 import { HallOfFameDialog } from "./HallOfFameDialog";
 import { showToast } from "components/Common/Shared/appToaster";
 import { HotkeyIndicator } from "components/Common/Shared";
+import { copyNuzlockeData, CopyNuzlockeDataMode } from "./copyNuzlockeData";
 
 export interface NuzlockeSaveControlsProps {
     nuzlockes: State["nuzlockes"];
@@ -42,6 +44,7 @@ export interface NuzlockeSaveControlsProps {
     switchNuzlocke: switchNuzlocke;
     replaceState: replaceState;
     updateSwitchNuzlocke: updateSwitchNuzlocke;
+    selectPokemon: selectPokemon;
 }
 
 export interface NuzlockeSaveControlsState {
@@ -94,6 +97,35 @@ export class NuzlockeSaveBase extends React.Component<
 
     private toggleIsHofOpen = () => {
         this.setState((state) => ({ isHofOpen: !state.isHofOpen }));
+    };
+
+    private copyFromNuzlocke = (
+        sourceData: State,
+        mode: CopyNuzlockeDataMode,
+        successLabel: string,
+    ) => {
+        const { nuzlockes, state, replaceState, updateNuzlocke, selectPokemon } =
+            this.props;
+        const { currentId } = nuzlockes;
+
+        try {
+            const targetData = JSON.parse(state) as State;
+            const nextData = copyNuzlockeData(targetData, sourceData, mode);
+            const nextDataString = JSON.stringify(nextData);
+
+            replaceState(nextData);
+            selectPokemon(nextData.selectedId);
+            updateNuzlocke(currentId, nextDataString);
+            showToast({
+                message: `${successLabel} copied to the current Nuzlocke.`,
+                intent: Intent.SUCCESS,
+            });
+        } catch (e) {
+            showToast({
+                message: `Failed to copy data to the current Nuzlocke. ${e}`,
+                intent: Intent.DANGER,
+            });
+        }
     };
 
     public renderMenu() {
@@ -259,6 +291,45 @@ export class NuzlockeSaveBase extends React.Component<
                                             }}
                                             text="Copy this Nuzlocke"
                                         ></MenuItem>
+                                        <MenuItem
+                                            shouldDismissPopover={false}
+                                            disabled={isCurrent}
+                                            icon="duplicate"
+                                            onClick={() =>
+                                                this.copyFromNuzlocke(
+                                                    parsedData,
+                                                    "pokemon",
+                                                    "Pokémon",
+                                                )
+                                            }
+                                            text="Copy Pokémon to Current Nuzlocke"
+                                        />
+                                        <MenuItem
+                                            shouldDismissPopover={false}
+                                            disabled={isCurrent}
+                                            icon="box"
+                                            onClick={() =>
+                                                this.copyFromNuzlocke(
+                                                    parsedData,
+                                                    "boxes",
+                                                    "Boxes",
+                                                )
+                                            }
+                                            text="Copy Boxes to Current Nuzlocke"
+                                        />
+                                        <MenuItem
+                                            shouldDismissPopover={false}
+                                            disabled={isCurrent}
+                                            icon="inbox"
+                                            onClick={() =>
+                                                this.copyFromNuzlocke(
+                                                    parsedData,
+                                                    "boxes-and-pokemon",
+                                                    "Boxes and Pokémon",
+                                                )
+                                            }
+                                            text="Copy Boxes and Pokémon to Current Nuzlocke"
+                                        />
                                         {feature.hallOfFame && (
                                             <MenuItem
                                                 shouldDismissPopover={false}
@@ -339,5 +410,6 @@ export const NuzlockeSave = connect(
         switchNuzlocke,
         replaceState,
         updateSwitchNuzlocke,
+        selectPokemon,
     },
 )(NuzlockeSaveBase);

--- a/src/components/Editors/SavesEditor/__tests__/copyNuzlockeData.test.ts
+++ b/src/components/Editors/SavesEditor/__tests__/copyNuzlockeData.test.ts
@@ -1,0 +1,100 @@
+import { copyNuzlockeData } from "../copyNuzlockeData";
+import { createDefaultState } from "store";
+import { State } from "state";
+
+const createState = (overrides: Partial<State>): State => ({
+    ...createDefaultState(),
+    ...overrides,
+});
+
+describe("copyNuzlockeData", () => {
+    it("copies pokemon and updates selectedId from the source save", () => {
+        const target = createState({
+            selectedId: "target-selected",
+            pokemon: [
+                {
+                    id: "target-selected",
+                    species: "Pikachu",
+                    status: "Team",
+                },
+            ],
+            box: [{ id: 0, name: "Team", position: 0 }],
+        });
+        const source = createState({
+            selectedId: "source-selected",
+            pokemon: [
+                {
+                    id: "source-selected",
+                    species: "Charizard",
+                    status: "Champs",
+                },
+            ],
+            box: [{ id: 9, name: "Legacy Champs", position: 0 }],
+        });
+
+        const result = copyNuzlockeData(target, source, "pokemon");
+
+        expect(result.pokemon).toEqual(source.pokemon);
+        expect(result.pokemon).not.toBe(source.pokemon);
+        expect(result.selectedId).toBe("source-selected");
+        expect(result.box).toEqual(target.box);
+    });
+
+    it("copies boxes without replacing pokemon", () => {
+        const target = createState({
+            selectedId: "target-selected",
+            pokemon: [{ id: "target-selected", species: "Eevee" }],
+            box: [{ id: 0, name: "Team", position: 0 }],
+        });
+        const source = createState({
+            selectedId: "source-selected",
+            pokemon: [{ id: "source-selected", species: "Vaporeon" }],
+            box: [{ id: 4, name: "Genlocke Champs", position: 1 }],
+        });
+
+        const result = copyNuzlockeData(target, source, "boxes");
+
+        expect(result.box).toEqual(source.box);
+        expect(result.box).not.toBe(source.box);
+        expect(result.pokemon).toEqual(target.pokemon);
+        expect(result.selectedId).toBe("target-selected");
+    });
+
+    it("copies boxes and pokemon together", () => {
+        const target = createState({
+            selectedId: "target-selected",
+            pokemon: [{ id: "target-selected", species: "Bulbasaur" }],
+            box: [{ id: 0, name: "Team", position: 0 }],
+        });
+        const source = createState({
+            selectedId: "source-selected",
+            pokemon: [{ id: "source-selected", species: "Blastoise" }],
+            box: [{ id: 2, name: "Transferred", position: 3 }],
+        });
+
+        const result = copyNuzlockeData(target, source, "boxes-and-pokemon");
+
+        expect(result.box).toEqual(source.box);
+        expect(result.pokemon).toEqual(source.pokemon);
+        expect(result.selectedId).toBe("source-selected");
+    });
+
+    it("falls back to the first copied pokemon when source selectedId is missing", () => {
+        const target = createState({
+            selectedId: "target-selected",
+            pokemon: [{ id: "target-selected", species: "Bulbasaur" }],
+        });
+        const source = createState({
+            selectedId: "missing",
+            pokemon: [
+                { id: "first-source", species: "Squirtle" },
+                { id: "second-source", species: "Wartortle" },
+            ],
+        });
+
+        const result = copyNuzlockeData(target, source, "pokemon");
+
+        expect(result.selectedId).toBe("first-source");
+    });
+});
+

--- a/src/components/Editors/SavesEditor/copyNuzlockeData.ts
+++ b/src/components/Editors/SavesEditor/copyNuzlockeData.ts
@@ -1,0 +1,42 @@
+import { State } from "state";
+
+export type CopyNuzlockeDataMode = "pokemon" | "boxes" | "boxes-and-pokemon";
+
+const cloneJsonValue = <T,>(value: T): T =>
+    JSON.parse(JSON.stringify(value)) as T;
+
+const copyPokemon = (
+    targetData: State,
+    sourceData: State,
+): Pick<State, "pokemon" | "selectedId"> => {
+    const pokemon = cloneJsonValue(sourceData.pokemon ?? []);
+    const selectedId =
+        sourceData.selectedId &&
+        pokemon.some((poke) => poke.id === sourceData.selectedId)
+            ? sourceData.selectedId
+            : pokemon[0]?.id ?? targetData.selectedId;
+
+    return {
+        pokemon,
+        selectedId,
+    };
+};
+
+export const copyNuzlockeData = (
+    targetData: State,
+    sourceData: State,
+    mode: CopyNuzlockeDataMode,
+): State => {
+    const nextData = { ...targetData };
+
+    if (mode === "boxes" || mode === "boxes-and-pokemon") {
+        nextData.box = cloneJsonValue(sourceData.box ?? []);
+    }
+
+    if (mode === "pokemon" || mode === "boxes-and-pokemon") {
+        Object.assign(nextData, copyPokemon(targetData, sourceData));
+    }
+
+    return nextData;
+};
+


### PR DESCRIPTION
## Summary
- adds save menu actions to copy Pokémon, boxes, or both from another Nuzlocke into the current Nuzlocke
- keeps the current save record in sync after copied data is applied
- adds focused tests for Pokémon-only, boxes-only, combined copy, and selected Pokémon fallback behavior

Fixes #938

## Validation
- npm run test:run -- src/components/Editors/SavesEditor/__tests__/copyNuzlockeData.test.ts
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8126: seeded current Red and source Blue saves, opened the source save menu, clicked Copy Boxes and Pokémon to Current Nuzlocke, and confirmed app state plus the current save record persisted Charizard, Legacy Champs, and selectedId source-charizard.