### PR TITLE
Normalize custom route checklist entries

### DIFF
--- a/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
+++ b/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
@@ -16,6 +16,12 @@ import { cx } from "emotion";
 import { useDispatch } from "store/reactZustand";
 import { updateExcludedAreas, updateCustomAreas } from "actions";
 
+export const normalizeAreaLines = (value: string) =>
+    value
+        .split("\n")
+        .map((area) => area.trim())
+        .filter(Boolean);
+
 const EncounterMap = ({
     encounterMap,
     style,
@@ -171,14 +177,12 @@ export const PokemonLocationChecklist = ({
 
     const updateExcludedAreasFromText = (event) => {
         const value = event.currentTarget.value;
-        const areas = value.split("\n");
-        dispatch(updateExcludedAreas(areas));
+        dispatch(updateExcludedAreas(normalizeAreaLines(value)));
     };
 
     const updateCustomAreasFromText = (event) => {
         const value = event.currentTarget.value;
-        const areas = value.split("\n");
-        dispatch(updateCustomAreas(areas));
+        dispatch(updateCustomAreas(normalizeAreaLines(value)));
     };
 
     const colors = [
@@ -299,10 +303,11 @@ export const PokemonLocationChecklist = ({
                     onChange={updateExcludedAreasFromText}
                     value={excludedAreas.join("\n")}
                 />
-                <div>Custom Areas</div>
+                <div>Custom Routes / Areas</div>
                 <TextArea
                     fill
                     name="customAreas"
+                    placeholder={"Route 1\nGale Forest\nOld Graveyard"}
                     onChange={updateCustomAreasFromText}
                     value={customAreas.join("\n")}
                 />

--- a/src/components/Editors/PokemonEditor/__tests__/PokemonLocationChecklist.test.ts
+++ b/src/components/Editors/PokemonEditor/__tests__/PokemonLocationChecklist.test.ts
@@ -1,0 +1,10 @@
+import { normalizeAreaLines } from "../PokemonLocationChecklist";
+
+describe("normalizeAreaLines", () => {
+    it("trims custom route lines and removes blanks", () => {
+        expect(
+            normalizeAreaLines(" Route 1 \n\nGale Forest\n Old Graveyard "),
+        ).toEqual(["Route 1", "Gale Forest", "Old Graveyard"]);
+    });
+});
+


### PR DESCRIPTION
## Summary
- labels the checklist custom location field as Custom Routes / Areas
- trims pasted custom route lines and removes blank lines before storing them
- adds focused coverage for custom route line normalization

Fixes #914

## Validation
- npm run test:run -- src/components/Editors/PokemonEditor/__tests__/PokemonLocationChecklist.test.ts
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8127: opened Location Checklist, confirmed Custom Routes / Areas is visible, entered whitespace-padded route lines, and confirmed persisted customAreas became [Gale Forest, Old Graveyard] while both routes appeared in the checklist.