### PR TITLE
Add location checklist sorting

### DIFF
--- a/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
+++ b/src/components/Editors/PokemonEditor/PokemonLocationChecklist.tsx
@@ -16,6 +16,21 @@ import { cx } from "emotion";
 import { useDispatch } from "store/reactZustand";
 import { updateExcludedAreas, updateCustomAreas } from "actions";
 
+export type LocationChecklistSort = "map-order" | "alphabetical";
+
+export const sortEncounterAreas = (
+    areas: string[],
+    sortMode: LocationChecklistSort,
+) => {
+    if (sortMode === "alphabetical") {
+        return [...areas].sort((left, right) =>
+            left.localeCompare(right, undefined, { numeric: true }),
+        );
+    }
+
+    return areas;
+};
+
 const EncounterMap = ({
     encounterMap,
     style,
@@ -142,6 +157,8 @@ export const PokemonLocationChecklist = ({
 
     const [excludeGifts, setExcludeGifts] = React.useState(false);
     const [currentGame, setCurrentGame] = React.useState<GameName>("None");
+    const [sortMode, setSortMode] =
+        React.useState<LocationChecklistSort>("map-order");
     const dispatch = useDispatch();
     const locationLookup = React.useMemo(() => {
         const map = new Map<string, Pokemon>();
@@ -161,6 +178,10 @@ export const PokemonLocationChecklist = ({
                 .concat(customAreas)
                 .filter((area) => !excludedAreas.includes(area)),
         [game.name, excludedAreas, customAreas],
+    );
+    const sortedEncounterMap = React.useMemo(
+        () => sortEncounterAreas(encounterMap, sortMode),
+        [encounterMap, sortMode],
     );
     const totals = React.useMemo(
         () => calcTotals(boxes, pokemon, encounterMap, currentGame),
@@ -277,12 +298,30 @@ export const PokemonLocationChecklist = ({
                         ))}
                     </HTMLSelect>
                 </label>
+                <label
+                    className={cx(Classes.CONTROL)}
+                    style={{ margin: ".25rem 0" }}
+                >
+                    <span className={Classes.LABEL}>Sort</span>
+                    <HTMLSelect
+                        value={sortMode}
+                        style={{ marginLeft: "0.25rem" }}
+                        onChange={(e) =>
+                            setSortMode(
+                                e?.target.value as LocationChecklistSort,
+                            )
+                        }
+                    >
+                        <option value="map-order">Map Order</option>
+                        <option value="alphabetical">Alphabetical</option>
+                    </HTMLSelect>
+                </label>
             </div>
             <div className="flex" style={{ justifyContent: "center" }}>
                 {buildTotals(totals)}
             </div>
             <EncounterMap
-                encounterMap={encounterMap}
+                encounterMap={sortedEncounterMap}
                 pokemon={pokemon}
                 style={style}
                 currentGame={currentGame}

--- a/src/components/Editors/PokemonEditor/__tests__/PokemonLocationChecklist.test.ts
+++ b/src/components/Editors/PokemonEditor/__tests__/PokemonLocationChecklist.test.ts
@@ -1,0 +1,18 @@
+import { sortEncounterAreas } from "../PokemonLocationChecklist";
+
+describe("sortEncounterAreas", () => {
+    const areas = ["Route 10", "Route 2", "Gale Forest"];
+
+    it("preserves map order by default", () => {
+        expect(sortEncounterAreas(areas, "map-order")).toEqual(areas);
+    });
+
+    it("sorts areas alphabetically with numeric route ordering", () => {
+        expect(sortEncounterAreas(areas, "alphabetical")).toEqual([
+            "Gale Forest",
+            "Route 2",
+            "Route 10",
+        ]);
+    });
+});
+


### PR DESCRIPTION
## Summary
- add a Sort control to the Pokemon Location Checklist with Map Order and Alphabetical modes
- keep Map Order as the default so existing checklist order is unchanged
- sort alphabetically with numeric route ordering, so Route 2 comes before Route 10

Fixes #913

## Validation
- npm run test:run -- src/components/Editors/PokemonEditor/__tests__/PokemonLocationChecklist.test.ts
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8128/: expanded Location Checklist, entered custom areas Route 10 / Route 2 / Gale Forest, confirmed Map Order preserves entry order and Alphabetical shows Gale Forest / Route 2 / Route 10.