### PR TITLE
Add missing G-Max and Hisuian form options

### DIFF
--- a/src/utils/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/utils.test.ts.snap
@@ -209,6 +209,7 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Meowth": [
       "Alolan",
       "Galarian",
+      "Gigantamax",
     ],
   },
   {
@@ -234,7 +235,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     ],
   },
   {
-    "Arcanine": [],
+    "Arcanine": [
+      "Hisuian",
+    ],
   },
   {
     "Poliwag": [],
@@ -394,7 +397,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     ],
   },
   {
-    "Electrode": [],
+    "Electrode": [
+      "Hisuian",
+    ],
   },
   {
     "Exeggcute": [],
@@ -603,7 +608,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Quilava": [],
   },
   {
-    "Typhlosion": [],
+    "Typhlosion": [
+      "Hisuian",
+    ],
   },
   {
     "Totodile": [],
@@ -1800,7 +1807,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Dewott": [],
   },
   {
-    "Samurott": [],
+    "Samurott": [
+      "Hisuian",
+    ],
   },
   {
     "Patrat": [],
@@ -2517,7 +2526,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Goomy": [],
   },
   {
-    "Sliggoo": [],
+    "Sliggoo": [
+      "Hisuian",
+    ],
   },
   {
     "Goodra": [
@@ -2586,7 +2597,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Dartrix": [],
   },
   {
-    "Decidueye": [],
+    "Decidueye": [
+      "Hisuian",
+    ],
   },
   {
     "Litten": [],
@@ -2915,7 +2928,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Corvisquire": [],
   },
   {
-    "Corviknight": [],
+    "Corviknight": [
+      "Gigantamax",
+    ],
   },
   {
     "Blipbug": [],
@@ -3085,6 +3100,7 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
       "Ruby Swirl",
       "Caramel Swirl",
       "Rainbow Swirl",
+      "Gigantamax",
     ],
   },
   {
@@ -3134,7 +3150,9 @@ exports[`getAdditionalFormes > matches snapshot for all species 1`] = `
     "Arctovish": [],
   },
   {
-    "Duraludon": [],
+    "Duraludon": [
+      "Gigantamax",
+    ],
   },
   {
     "Dreepy": [],

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -86,6 +86,84 @@ describe("styleDefaults", () => {
     });
 });
 
+describe("getAdditionalFormes", () => {
+    it("includes every Gigantamax species option", () => {
+        const gigantamaxSpecies = [
+            "Venusaur",
+            "Charizard",
+            "Blastoise",
+            "Butterfree",
+            "Pikachu",
+            "Meowth",
+            "Machamp",
+            "Gengar",
+            "Kingler",
+            "Lapras",
+            "Eevee",
+            "Snorlax",
+            "Garbodor",
+            "Melmetal",
+            "Rillaboom",
+            "Cinderace",
+            "Inteleon",
+            "Corviknight",
+            "Orbeetle",
+            "Drednaw",
+            "Coalossal",
+            "Flapple",
+            "Appletun",
+            "Sandaconda",
+            "Toxtricity",
+            "Centiskorch",
+            "Hatterene",
+            "Grimmsnarl",
+            "Alcremie",
+            "Copperajah",
+            "Duraludon",
+        ];
+
+        const missing = gigantamaxSpecies.filter(
+            (species) => !getAdditionalFormes(species).includes("Gigantamax"),
+        );
+
+        expect(missing).toEqual([]);
+
+        expect(getAdditionalFormes("Urshifu")).toEqual(
+            expect.arrayContaining([
+                "Single Strike Gigantamax",
+                "Rapid Strike Gigantamax",
+            ]),
+        );
+    });
+
+    it("includes every Hisuian regional form option", () => {
+        const hisuianSpecies = [
+            "Growlithe",
+            "Arcanine",
+            "Voltorb",
+            "Electrode",
+            "Typhlosion",
+            "Qwilfish",
+            "Sneasel",
+            "Samurott",
+            "Lilligant",
+            "Zorua",
+            "Zoroark",
+            "Braviary",
+            "Sliggoo",
+            "Goodra",
+            "Avalugg",
+            "Decidueye",
+        ];
+
+        const missing = hisuianSpecies.filter(
+            (species) => !getAdditionalFormes(species).includes("Hisuian"),
+        );
+
+        expect(missing).toEqual([]);
+    });
+});
+
 describe("matchSpeciesToType", () => {
     it("returns a type for a Pokemon", () => {
         expect(matchSpeciesToTypes("Bulbasaur")).toEqual(["Grass", "Poison"]);
@@ -110,6 +188,38 @@ describe("matchSpeciesToType", () => {
         expect(matchSpeciesToTypes("Shaymin", "Sky")).toEqual([
             "Grass",
             "Flying",
+        ]);
+        expect(matchSpeciesToTypes("Arcanine", "Hisuian")).toEqual([
+            "Fire",
+            "Rock",
+        ]);
+        expect(matchSpeciesToTypes("Electrode", "Hisuian")).toEqual([
+            "Electric",
+            "Grass",
+        ]);
+        expect(matchSpeciesToTypes("Typhlosion", "Hisuian")).toEqual([
+            "Fire",
+            "Ghost",
+        ]);
+        expect(matchSpeciesToTypes("Samurott", "Hisuian")).toEqual([
+            "Water",
+            "Dark",
+        ]);
+        expect(matchSpeciesToTypes("Lilligant", "Hisuian")).toEqual([
+            "Grass",
+            "Fighting",
+        ]);
+        expect(matchSpeciesToTypes("Goodra", "Hisuian")).toEqual([
+            "Steel",
+            "Dragon",
+        ]);
+        expect(matchSpeciesToTypes("Avalugg", "Hisuian")).toEqual([
+            "Ice",
+            "Rock",
+        ]);
+        expect(matchSpeciesToTypes("Decidueye", "Hisuian")).toEqual([
+            "Grass",
+            "Fighting",
         ]);
         listOfPokemon.map((pokemon, index) => {
             expect(matchSpeciesToTypes(pokemon).length).toBeGreaterThan(0);

--- a/src/utils/formatters/matchSpeciesToTypes.ts
+++ b/src/utils/formatters/matchSpeciesToTypes.ts
@@ -535,12 +535,32 @@ export const handleSpeciesTypeEdgeCases = ({
         return [Types.Normal, Types.Fighting];
     }
 
-    if (match({ ...data, species: ["Growlithe"], forme: ["Hisuian"] })) {
+    if (
+        match({
+            ...data,
+            species: ["Growlithe", "Arcanine"],
+            forme: ["Hisuian"],
+        })
+    ) {
         return [Types.Fire, Types.Rock];
     }
 
-    if (match({ ...data, species: ["Voltorb"], forme: ["Hisuian"] })) {
+    if (
+        match({
+            ...data,
+            species: ["Voltorb", "Electrode"],
+            forme: ["Hisuian"],
+        })
+    ) {
         return [Types.Electric, Types.Grass];
+    }
+
+    if (match({ ...data, species: ["Typhlosion"], forme: ["Hisuian"] })) {
+        return [Types.Fire, Types.Ghost];
+    }
+
+    if (match({ ...data, species: ["Samurott"], forme: ["Hisuian"] })) {
+        return [Types.Water, Types.Dark];
     }
 
     if (match({ ...data, species: ["Zorua", "Zoroark"], forme: ["Hisuian"] })) {
@@ -557,6 +577,22 @@ export const handleSpeciesTypeEdgeCases = ({
 
     if (match({ ...data, species: ["Qwilfish"], forme: ["Hisuian"] })) {
         return [Types.Dark, Types.Poison];
+    }
+
+    if (match({ ...data, species: ["Lilligant"], forme: ["Hisuian"] })) {
+        return [Types.Grass, Types.Fighting];
+    }
+
+    if (match({ ...data, species: ["Sliggoo", "Goodra"], forme: ["Hisuian"] })) {
+        return [Types.Steel, Types.Dragon];
+    }
+
+    if (match({ ...data, species: ["Avalugg"], forme: ["Hisuian"] })) {
+        return [Types.Ice, Types.Rock];
+    }
+
+    if (match({ ...data, species: ["Decidueye"], forme: ["Hisuian"] })) {
+        return [Types.Grass, Types.Fighting];
     }
 
     if (match({ ...data, species: ["Wooper"], forme: ["Paldean"] })) {

--- a/src/utils/getters/getAdditionalFormes.ts
+++ b/src/utils/getters/getAdditionalFormes.ts
@@ -160,7 +160,7 @@ export const getAdditionalFormes = (species: string | undefined): string[] => {
         return ["Alolan"];
     }
     if (s === "meowth") {
-        return ["Alolan", "Galarian"];
+        return ["Alolan", "Galarian", "Gigantamax"];
     }
     if (
         s === "ponyta" ||
@@ -304,13 +304,14 @@ export const getAdditionalFormes = (species: string | undefined): string[] => {
             "Ruby Swirl",
             "Caramel Swirl",
             "Rainbow Swirl",
+            "Gigantamax",
         ];
     }
     if (
         s === "snorlax" ||
         s === "eevee" ||
         s === "butterfree" ||
-        s === "corvinight" ||
+        s === "corviknight" ||
         s === "alcremie" ||
         s === "drednaw" ||
         s === "machamp" ||
@@ -321,7 +322,7 @@ export const getAdditionalFormes = (species: string | undefined): string[] => {
         s === "grimmsnarl" ||
         s === "hatterene" ||
         s === "copperajah" ||
-        s === "duralodon" ||
+        s === "duraludon" ||
         s === "flapple" ||
         s === "appletun" ||
         s === "orbeetle" ||
@@ -344,16 +345,21 @@ export const getAdditionalFormes = (species: string | undefined): string[] => {
     }
     if (
         s === "growlithe" ||
+        s === "arcanine" ||
         s === "voltorb" ||
+        s === "electrode" ||
+        s === "typhlosion" ||
+        s === "samurott" ||
         s === "zorua" ||
         s === "zoroark" ||
         s === "braviary" ||
         s === "sneasel" ||
-        s === "sligoo" ||
+        s === "sliggoo" ||
         s === "goodra" ||
         s === "avalugg" ||
         s === "lilligant" ||
-        s === "qwilfish"
+        s === "qwilfish" ||
+        s === "decidueye"
     ) {
         return ["Hisuian"];
     }


### PR DESCRIPTION
## Summary
- add missing Gigantamax form options for Meowth, Corviknight, Alcremie, and Duraludon
- add missing Hisuian form options for Arcanine, Electrode, Typhlosion, Samurott, Sliggoo, and Decidueye
- add missing Hisuian type overrides so selected forms update their typings correctly
- add regression coverage for every Gigantamax and Hisuian selector option

Fixes #859

## Validation
- npm run test:run -- src/utils/__tests__/utils.test.ts
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8129/: changed Species to Meowth and confirmed the Forme select includes/accepts Gigantamax; changed Species to Goodra, selected Hisuian, and confirmed type selectors updated to Steel / Dragon.