### PR TITLE
Add nickname preset list support

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -35,6 +35,7 @@ export * from "./triggerDownload";
 export * from "./toggleDialog";
 export * from "./updateExcludedAreas";
 export * from "./updateCustomAreas";
+export * from "./updateNicknamePresets";
 export * from "./syncStateFromHistory";
 export * from "./editHotkey";
 export * from "./saveUploadSettings";

--- a/src/actions/updateNicknamePresets.ts
+++ b/src/actions/updateNicknamePresets.ts
@@ -1,0 +1,18 @@
+import { Action } from "./action";
+
+export type UPDATE_NICKNAME_PRESETS = "UPDATE_NICKNAME_PRESETS";
+export const UPDATE_NICKNAME_PRESETS: UPDATE_NICKNAME_PRESETS =
+    "UPDATE_NICKNAME_PRESETS";
+
+export type updateNicknamePresets = (
+    nicknamePresets: string[],
+) => Action<UPDATE_NICKNAME_PRESETS>;
+
+export function updateNicknamePresets(
+    nicknamePresets: string[],
+): Action<UPDATE_NICKNAME_PRESETS> {
+    return {
+        type: UPDATE_NICKNAME_PRESETS,
+        nicknamePresets,
+    };
+}

--- a/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
+++ b/src/components/Editors/PokemonEditor/CurrentPokemonEdit.tsx
@@ -14,6 +14,7 @@ import {
     listOfPokeballs,
     listOfPokemon,
     matchSpeciesToTypes,
+    parseNicknamePresetText,
     Species,
 } from "utils";
 import { Pokemon, Editor } from "models";
@@ -21,7 +22,7 @@ import { Boxes } from "models";
 import { CurrentPokemonInput } from "./CurrentPokemonInput";
 import { DeletePokemonButton } from "components/Pokemon/DeletePokemonButton/DeletePokemonButton";
 import { Autocomplete, ErrorBoundary } from "components/Common/Shared";
-import { selectPokemon, editPokemon } from "actions";
+import { selectPokemon, editPokemon, updateNicknamePresets } from "actions";
 import { connect } from "store/reactZustand";
 import { listOfGames, accentedE } from "utils";
 import { cx } from "emotion";
@@ -36,6 +37,8 @@ import {
     Button,
     Intent,
     ButtonGroup,
+    HTMLSelect,
+    TextArea,
     Tooltip,
 } from "@blueprintjs/core";
 import { addPokemon } from "actions";
@@ -88,6 +91,8 @@ export interface CurrentPokemonEditProps {
     editor: Editor;
     customTypes: State["customTypes"];
     customAreas: State["customAreas"];
+    nicknamePresets: State["nicknamePresets"];
+    updateNicknamePresets: updateNicknamePresets;
 }
 
 export interface CurrentPokemonEditState {
@@ -253,6 +258,12 @@ export class CurrentPokemonEditBase extends React.Component<
     private toggleDialog = () =>
         this.setState({ isMoveEditorOpen: !this.state.isMoveEditorOpen });
 
+    private setNicknamePreset = (nickname: string) => {
+        if (!nickname) return;
+        this.props.editPokemon({ nickname }, this.state.selectedId);
+        this.props.selectPokemon(this.state.selectedId);
+    };
+
     private getTypes(includeShadow = true) {
         const { customTypes, editor } = this.props;
         return getListOfTypes(customTypes, editor.temtemMode).filter((type) =>
@@ -284,6 +295,31 @@ export class CurrentPokemonEditBase extends React.Component<
                     pokemon={currentPokemon}
                     key={this.state.selectedId + "forme"}
                 />
+                <CurrentPokemonLayoutItem fullWidth>
+                    <span
+                        className="current-pokemon-input-wrapper"
+                        style={{ width: "100%" }}
+                    >
+                        <label htmlFor="nicknamePresetList">
+                            Nickname Presets
+                        </label>
+                        <TextArea
+                            id="nicknamePresetList"
+                            name="nicknamePresets"
+                            fill
+                            growVertically
+                            placeholder="One name per line, or comma-separated"
+                            value={this.props.nicknamePresets.join("\n")}
+                            onChange={(event) =>
+                                this.props.updateNicknamePresets(
+                                    parseNicknamePresetText(
+                                        event.currentTarget.value,
+                                    ),
+                                )
+                            }
+                        />
+                    </span>
+                </CurrentPokemonLayoutItem>
                 <CurrentPokemonInput
                     labelName="Types"
                     inputName="types"
@@ -662,6 +698,33 @@ export class CurrentPokemonEditBase extends React.Component<
                         type="text"
                         key={this.state.selectedId + "nickname"}
                     />
+                    <span className="current-pokemon-input-wrapper">
+                        <label htmlFor="nicknamePresetSelect">
+                            Preset Name
+                        </label>
+                        <HTMLSelect
+                            id="nicknamePresetSelect"
+                            name="nicknamePresetSelect"
+                            value=""
+                            disabled={!this.props.nicknamePresets.length}
+                            onChange={(event) =>
+                                this.setNicknamePreset(
+                                    event.currentTarget.value,
+                                )
+                            }
+                        >
+                            <option value="">
+                                {this.props.nicknamePresets.length
+                                    ? "Choose..."
+                                    : "No presets"}
+                            </option>
+                            {this.props.nicknamePresets.map((nickname) => (
+                                <option key={nickname} value={nickname}>
+                                    {nickname}
+                                </option>
+                            ))}
+                        </HTMLSelect>
+                    </span>
                 </CurrentPokemonLayoutItem>
                 <CurrentPokemonLayoutItem>
                     <CurrentPokemonInput
@@ -787,10 +850,12 @@ export const CurrentPokemonEdit = connect(
         editor: state.editor,
         customTypes: state.customTypes,
         customAreas: state.customAreas,
+        nicknamePresets: state.nicknamePresets,
     }),
     {
         selectPokemon,
         editPokemon,
         addPokemon,
+        updateNicknamePresets,
     },
 )(CurrentPokemonEditBase);

--- a/src/reducers/__tests__/nicknamePresets.test.ts
+++ b/src/reducers/__tests__/nicknamePresets.test.ts
@@ -1,0 +1,25 @@
+import { replaceState, syncStateFromHistory, updateNicknamePresets } from "actions";
+import { nicknamePresets } from "../nicknamePresets";
+
+describe("nicknamePresets", () => {
+    it("updates the preset name list", () => {
+        expect(nicknamePresets([], updateNicknamePresets(["Sage"]))).toEqual([
+            "Sage",
+        ]);
+    });
+
+    it("restores preset names from imported state", () => {
+        expect(
+            nicknamePresets(["Old"], replaceState({ nicknamePresets: ["Nova"] })),
+        ).toEqual(["Nova"]);
+    });
+
+    it("restores preset names from editor history", () => {
+        expect(
+            nicknamePresets(
+                ["Old"],
+                syncStateFromHistory({ nicknamePresets: ["Briar"] }),
+            ),
+        ).toEqual(["Briar"]);
+    });
+});

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -21,6 +21,7 @@ import { excludedAreas, customAreas } from "./areas";
 import { view } from "./view";
 import { hotkeys } from "./hotkeys";
 import { saveUploadSettings } from "./saveUploadSettings";
+import { nicknamePresets } from "./nicknamePresets";
 
 export const reducers = {
     box,
@@ -34,6 +35,7 @@ export const reducers = {
     game,
     hotkeys,
     nuzlockes,
+    nicknamePresets,
     pokemon,
     editor,
     saveUploadSettings,

--- a/src/reducers/nicknamePresets.ts
+++ b/src/reducers/nicknamePresets.ts
@@ -1,0 +1,25 @@
+import {
+    Action,
+    REPLACE_STATE,
+    SYNC_STATE_FROM_HISTORY,
+    UPDATE_NICKNAME_PRESETS,
+} from "../actions";
+import { State } from "state";
+
+export function nicknamePresets(
+    state: State["nicknamePresets"] = [],
+    action: Action<
+        UPDATE_NICKNAME_PRESETS | REPLACE_STATE | SYNC_STATE_FROM_HISTORY
+    >,
+) {
+    switch (action.type) {
+        case UPDATE_NICKNAME_PRESETS:
+            return action.nicknamePresets;
+        case REPLACE_STATE:
+            return action.replaceWith.nicknamePresets ?? [];
+        case SYNC_STATE_FROM_HISTORY:
+            return action.syncWith.nicknamePresets ?? [];
+        default:
+            return state;
+    }
+}

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -27,6 +27,7 @@ export interface State {
     customTypes: { type: string; color: string; id: string }[];
     stats: Record<"id" | "value" | "key", string | undefined>[];
     nuzlockes: Nuzlockes;
+    nicknamePresets: string[];
     editorHistory: History<Omit<State, "editorHistory">>;
     view: View;
 }

--- a/src/utils/__tests__/nicknamePresets.test.ts
+++ b/src/utils/__tests__/nicknamePresets.test.ts
@@ -1,0 +1,18 @@
+import { parseNicknamePresetText } from "utils";
+
+describe("parseNicknamePresetText", () => {
+    it("accepts newline and comma separated preset names", () => {
+        expect(parseNicknamePresetText("Briar\nNova, Sage")).toEqual([
+            "Briar",
+            "Nova",
+            "Sage",
+        ]);
+    });
+
+    it("trims blanks and keeps the first instance of duplicate names", () => {
+        expect(parseNicknamePresetText("  Briar  \n\nBriar, Nova ")).toEqual([
+            "Briar",
+            "Nova",
+        ]);
+    });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,3 +35,4 @@ export * from "./isEqual";
 export * from "./editorDarkModePreference";
 export * from "./search";
 export * from "./searchTermStorage";
+export * from "./nicknamePresets";

--- a/src/utils/nicknamePresets.ts
+++ b/src/utils/nicknamePresets.ts
@@ -1,0 +1,12 @@
+export const parseNicknamePresetText = (value: string) => {
+    const seen = new Set<string>();
+
+    return value
+        .split(/[\n,]/)
+        .map((name) => name.trim())
+        .filter((name) => {
+            if (!name || seen.has(name)) return false;
+            seen.add(name);
+            return true;
+        });
+};


### PR DESCRIPTION
Fixes #816.

## Summary
- add persisted nickname presets to app state
- add a Pokémon editor preset-name selector for quick nickname application
- add a paste/import textarea that accepts newline or comma separated names and dedupes them

## Validation
- npm run test:run -- src/reducers/__tests__/nicknamePresets.test.ts src/utils/__tests__/nicknamePresets.test.ts
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- Browser smoke on http://127.0.0.1:8130/: imported `Briar\nNova, Sage\nBriar`, confirmed Preset Name options deduped to Briar/Nova/Sage, selected Nova, confirmed nickname updated and presets survived reload