### PR TITLE
Fix Gen 1 and Gen 2 save box imports

### DIFF
--- a/src/parsers/__tests__/gen1gen2Counts.test.ts
+++ b/src/parsers/__tests__/gen1gen2Counts.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "node:path";
+import { Buffer } from "buffer";
+import { parseGen1Save } from "../gen1";
+import { parseGen2Save } from "../gen2";
+import { BoxMappings } from "../utils/boxMappings";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const GEN1_BOX_OFFSETS = [
+    0x4000, 0x4462, 0x48c4, 0x4d26, 0x5188, 0x55ea, 0x6000, 0x6462, 0x68c4,
+    0x6d26, 0x7188, 0x75ea,
+];
+const GEN2_BOX_OFFSETS = [
+    0x4000, 0x4450, 0x48a0, 0x4cf0, 0x5140, 0x5590, 0x59e0, 0x6000, 0x6450,
+    0x68a0, 0x6cf0, 0x7140, 0x7590, 0x79e0,
+];
+
+const loadSav = (name: string) =>
+    Buffer.from(readFileSync(join(__dirname, "..", name)));
+
+const makeBoxMappings = (count: number): BoxMappings =>
+    Array.from({ length: count }, (_, index) => ({
+        key: index + 1,
+        status: "Boxed",
+        name: `Box ${index + 1}`,
+    }));
+
+const sumBoxCounts = (save: Buffer, offsets: number[]) =>
+    offsets.reduce((total, offset) => total + save[offset], 0);
+
+describe("Gen 1 and Gen 2 boxed Pokemon counts", () => {
+    it("parses only occupied Gen 1 boxed slots", async () => {
+        const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+        const save = loadSav("red.sav");
+
+        try {
+            const result = await parseGen1Save(save, {
+                boxMappings: makeBoxMappings(12),
+            });
+            const team = result.pokemon.filter((poke) => poke.status === "Team");
+            const boxed = result.pokemon.filter(
+                (poke) => poke.status === "Boxed",
+            );
+
+            expect(sumBoxCounts(save, GEN1_BOX_OFFSETS)).toBe(161);
+            expect(team).toHaveLength(6);
+            expect(boxed).toHaveLength(161);
+            expect(result.pokemon).toHaveLength(167);
+        } finally {
+            consoleLog.mockRestore();
+        }
+    });
+
+    it("parses only occupied Gen 2 boxed slots", async () => {
+        const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+        const save = loadSav("gold.sav");
+
+        try {
+            const result = await parseGen2Save(save, {
+                boxMappings: makeBoxMappings(14),
+                isCrystal: false,
+            });
+            const team = result.pokemon.filter((poke) => poke.status === "Team");
+            const boxed = result.pokemon.filter(
+                (poke) => poke.status === "Boxed",
+            );
+
+            expect(sumBoxCounts(save, GEN2_BOX_OFFSETS)).toBe(169);
+            expect(team).toHaveLength(6);
+            expect(boxed).toHaveLength(169);
+            expect(result.pokemon).toHaveLength(175);
+        } finally {
+            consoleLog.mockRestore();
+        }
+    });
+});

--- a/src/parsers/gen1.ts
+++ b/src/parsers/gen1.ts
@@ -37,6 +37,11 @@ const BOX_OFFSETS = [
     0x4000, 0x4462, 0x48c4, 0x4d26, 0x5188, 0x55ea, 0x6000, 0x6462, 0x68c4,
     0x6d26, 0x7188, 0x75ea,
 ];
+const PARTY_CAPACITY = 6;
+const PARTY_POKEMON_SIZE = 44;
+const BOX_CAPACITY = 20;
+const BOX_POKEMON_SIZE = 33;
+const POKEMON_NAME_SIZE = 11;
 
 const checksum = (data: Uint8Array) => {
     let checksumN = 255;
@@ -155,21 +160,33 @@ const parsePartyPokemon = (buf: Buffer, boxed = false) => {
     };
 };
 
-const getPokemonListForParty = (buf: Buffer, entries: number = 6) => {
-    const party = splitUp(Buffer.from(buf), entries);
+const getPokemonListForParty = (
+    buf: Buffer,
+    entries: number = PARTY_CAPACITY,
+) => {
+    if (entries <= 0) return [];
+    const party = splitUp(
+        Buffer.from(buf).slice(0, entries * PARTY_POKEMON_SIZE),
+        entries,
+    );
     const pokes = party.map((box) => parsePartyPokemon(box));
     return pokes;
 };
 
-const getPokemonListForBox = (buf: Buffer, entries: number = 6) => {
-    const box = splitUp(Buffer.from(buf), entries);
+const getPokemonListForBox = (buf: Buffer, entries: number = BOX_CAPACITY) => {
+    if (entries <= 0) return [];
+    const box = splitUp(
+        Buffer.from(buf).slice(0, entries * BOX_POKEMON_SIZE),
+        entries,
+    );
 
     const pokes = box.map((box) => parsePartyPokemon(box, true));
 
     return pokes;
 };
 
-const getPokemonNames = (buf: Buffer, entries: number = 6) => {
+const getPokemonNames = (buf: Buffer, entries: number = PARTY_CAPACITY) => {
+    if (entries <= 0) return [];
     const pokes = splitUp(Buffer.from(buf), entries);
     const names = pokes.map((poke) => convertWithCharMap(poke, true));
     return names;
@@ -194,15 +211,18 @@ const removeLastEntries = (entries: number, arr: unknown[]) => {
 
 const parsePokemonParty = (buf: Buffer) => {
     const party = Buffer.from(buf);
-    const entriesUsed = party[0x0000];
+    const entriesUsed = Math.min(party[0x0000], PARTY_CAPACITY);
     const rawSpeciesList = party.slice(0x0001, 0x0007);
     const speciesList = getSpeciesList(rawSpeciesList);
     const pokemonList = getPokemonListForParty(
-        party.slice(0x0008, 0x0008 + 264),
-        6,
+        party.slice(0x0008, 0x0008 + PARTY_CAPACITY * PARTY_POKEMON_SIZE),
+        entriesUsed,
     );
     const OTNames = party.slice(0x0110, 0x0110 + 66);
-    const pokemonNames = getPokemonNames(party.slice(0x0152, 0x152 + 66), 6);
+    const pokemonNames = getPokemonNames(
+        party.slice(0x0152, 0x152 + entriesUsed * POKEMON_NAME_SIZE),
+        entriesUsed,
+    );
 
     return {
         entriesUsed,
@@ -215,16 +235,16 @@ const parsePokemonParty = (buf: Buffer) => {
 
 const parseBoxedPokemon = (buf: Buffer): Gen1PokemonObject => {
     const box = Buffer.from(buf);
-    const entriesUsed = box[0x0000];
+    const entriesUsed = Math.min(box[0x0000], BOX_CAPACITY);
     const rawSpeciesList = box.slice(0x0001, 0x0001 + 21);
     const speciesList = getSpeciesList(rawSpeciesList);
     const pokemonList = getPokemonListForBox(
-        box.slice(0x0016, 0x0016 + 660),
+        box.slice(0x0016, 0x0016 + BOX_CAPACITY * BOX_POKEMON_SIZE),
         entriesUsed,
     );
     const OTNames = box.slice(0x02aa, 0x02aa + 220);
     const pokemonNames = getPokemonNames(
-        box.slice(0x0386, 0x0386 + 220),
+        box.slice(0x0386, 0x0386 + entriesUsed * POKEMON_NAME_SIZE),
         entriesUsed,
     );
 

--- a/src/parsers/gen2.ts
+++ b/src/parsers/gen2.ts
@@ -97,6 +97,11 @@ const OFFSETS = {
         [0x79e0, 0x79e0 + 1102],
     ],
 };
+const PARTY_CAPACITY = 6;
+const BOX_CAPACITY = 20;
+const PARTY_POKEMON_SIZE = 48;
+const BOX_POKEMON_SIZE = 32;
+const POKEMON_NAME_SIZE = 11;
 
 const CRYSTAL_OFFSETS = {
     PLAYER_MONEY: [0x23dc, 0x23dc + 3],
@@ -341,15 +346,17 @@ const getSpeciesList = (buf: Buffer) => {
 
 const getPokemonList = (
     buf: Buffer,
-    entries: number = 6,
+    entries: number = PARTY_CAPACITY,
     boxed: boolean = false,
 ) => {
+    if (entries <= 0) return [];
     const party = splitUp(Buffer.from(buf), entries);
     const pokes = party.map((box) => parsePokemon(box, boxed));
     return pokes;
 };
 
-const getPokemonNames = (buf: Buffer, entries: number = 6) => {
+const getPokemonNames = (buf: Buffer, entries: number = PARTY_CAPACITY) => {
+    if (entries <= 0) return [];
     const names = splitUp(Buffer.from(buf), entries);
     const pokes = names.map((name) => convertWithCharMap(name, true));
     return pokes;
@@ -414,30 +421,33 @@ const makeFileSlicer = (file) => (offset: number[]) => {
 
 export const parsePokemonList = (
     buf: Buffer,
-    entries = 6,
+    entries = PARTY_CAPACITY,
 ): Gen2PokemonObject => {
     const data = Buffer.from(buf);
-    const isBoxed = entries > 6 ? true : false;
+    const isBoxed = entries > PARTY_CAPACITY ? true : false;
+    const maxEntries = isBoxed ? BOX_CAPACITY : PARTY_CAPACITY;
     const entriesUsed = data[0x00];
+    const parsedEntries = Math.min(entriesUsed, maxEntries);
     const speciesListEnd = 0x01 + entries + 1;
     const speciesList = getSpeciesList(
-        Buffer.from(data.slice(0x01, speciesListEnd)),
+        Buffer.from(data.slice(0x01, 0x01 + parsedEntries)),
     );
     const pokemonListAddress = speciesListEnd;
+    const pokemonSize = isBoxed ? BOX_POKEMON_SIZE : PARTY_POKEMON_SIZE;
     const pokemonListAddressEnd =
-        pokemonListAddress + (isBoxed ? 32 : 48) * entries;
-    const otsAddress = pokemonListAddressEnd;
-    const otsAddressEnd = otsAddress + 11 * entries;
-    const pokemonNamesAddress = otsAddressEnd;
-    const pokemonNamesAddressEnd = pokemonNamesAddress + 11 * entries;
+        pokemonListAddress + pokemonSize * parsedEntries;
+    const pokemonNamesAddress =
+        pokemonListAddress + pokemonSize * entries + POKEMON_NAME_SIZE * entries;
+    const pokemonNamesAddressEnd =
+        pokemonNamesAddress + POKEMON_NAME_SIZE * parsedEntries;
     const pokemonList = getPokemonList(
         data.slice(pokemonListAddress, pokemonListAddressEnd),
-        entries,
+        parsedEntries,
         isBoxed,
     );
     const pokemonNames = getPokemonNames(
         data.slice(pokemonNamesAddress, pokemonNamesAddressEnd),
-        entries,
+        parsedEntries,
     );
 
     return {


### PR DESCRIPTION
Fixes #792.

## Summary
- respect occupied-slot count bytes when parsing Gen 1 and Gen 2 boxed Pokemon
- keep Gen 2 name offsets based on box capacity while only decoding populated rows
- add fixture regression coverage for `red.sav` and `gold.sav` total import counts

## Validation
- `npm run test:run -- src/parsers/__tests__/gen1gen2Counts.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `http://127.0.0.1:8131/`: uploaded `src/parsers/red.sav` through the import-save file input and confirmed persisted state had 167 Pokemon total: 6 Team, 141 Boxed, 20 Dead; first boxed Pokemon were Bulbasaur, Ivysaur, Venusaur