### PR TITLE
Make custom version names explicit

### DIFF
--- a/src/components/Editors/GameEditor/GameEditor.tsx
+++ b/src/components/Editors/GameEditor/GameEditor.tsx
@@ -28,6 +28,7 @@ export interface GameEditorProps {
 const gameSubEditorStyle: React.CSSProperties = {
     display: "flex",
     justifyContent: "space-between",
+    alignItems: "center",
     paddingBottom: ".25rem",
 };
 
@@ -99,9 +100,13 @@ export class GameEditorBase extends React.Component<
                         <div style={{ fontSize: "80%" }}>
                             <label
                                 className={Classes.INLINE}
-                                style={{ marginRight: "calc(.75rem + 2px)" }}
+                                style={{
+                                    display: "inline-block",
+                                    marginRight: ".5rem",
+                                    width: "4.75rem",
+                                }}
                             >
-                                Name
+                                Custom Version
                             </label>
                             <input
                                 onChange={this.onInputName}
@@ -111,7 +116,7 @@ export class GameEditorBase extends React.Component<
                                 style={{ width: controlWidth }}
                                 className={Classes.INPUT}
                                 type="text"
-                                placeholder={game.name}
+                                placeholder={`Custom ${game.name} name`}
                             />
                         </div>
                         {feature.temTemMode && (

--- a/src/components/Editors/GameEditor/__tests__/GameEditor.test.tsx
+++ b/src/components/Editors/GameEditor/__tests__/GameEditor.test.tsx
@@ -36,7 +36,11 @@ describe("<GameEditor />", () => {
         const props = createProps();
         render(<GameEditorBase {...props} />);
 
-        const input = screen.getByPlaceholderText(props.game.name);
+        expect(screen.getByText("Custom Version")).toBeDefined();
+
+        const input = screen.getByPlaceholderText(
+            `Custom ${props.game.name} name`,
+        );
         fireEvent.change(input, { target: { value: "My Run" } });
 
         expect(props.editGame).toHaveBeenCalledWith({ customName: "My Run" });

--- a/src/components/Features/Result/TrainerResult.tsx
+++ b/src/components/Features/Result/TrainerResult.tsx
@@ -162,6 +162,7 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
 
     public render() {
         const { trainer, game, style, orientation, checkpoints } = this.props;
+        const displayGameName = game.customName || game.name;
         const isVertical = orientation === "vertical";
         const baseDivStyle = isVertical
             ? { padding: "2px" }
@@ -199,7 +200,7 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
                         padding: "2px",
                     }}
                 >
-                    {game.customName || game.name}
+                    {displayGameName}
                 </div>
                 {trainer.image ? (
                     <img
@@ -214,7 +215,7 @@ export class TrainerResultBase extends React.Component<TrainerResultProps> {
                     </div>
                 ) : (
                     <div style={baseDivStyle} className="nuzlocke-title">
-                        {this.props.game.name} Nuzlocke
+                        {displayGameName} Nuzlocke
                     </div>
                 )}
                 {feature.resultv2 ? (

--- a/src/components/Features/Result/__tests__/TrainerResult.test.tsx
+++ b/src/components/Features/Result/__tests__/TrainerResult.test.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { render, screen } from "utils/testUtils";
+import { TrainerResultBase } from "../TrainerResult";
+import { styleDefaults } from "utils";
+
+describe("<TrainerResult />", () => {
+    it("uses a custom version name in the badge and default title", () => {
+        render(
+            <TrainerResultBase
+                orientation="vertical"
+                checkpoints={[]}
+                trainer={{ badges: [] }}
+                game={{ name: "FireRed", customName: "Radical Red" }}
+                style={{
+                    ...styleDefaults,
+                    displayBadges: false,
+                    displayRules: false,
+                }}
+                rules={[]}
+            />,
+        );
+
+        expect(screen.getByText("Radical Red")).toBeDefined();
+        expect(screen.getByText("Radical Red Nuzlocke")).toBeDefined();
+        expect(screen.queryByText("FireRed Nuzlocke")).toBeNull();
+    });
+});


### PR DESCRIPTION
Fixes #738.

## Summary
- relabel the game custom-name field as `Custom Version` with a version-aware placeholder
- use the custom version name for the generated result title when no trainer title is set
- add GameEditor and TrainerResult coverage for custom version behavior

## Validation
- `npm run test:run -- src/components/Editors/GameEditor/__tests__/GameEditor.test.tsx src/components/Features/Result/__tests__/TrainerResult.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Browser smoke on `http://127.0.0.1:8132/`: selected `FireRed`, entered `Radical Red`, confirmed persisted `game` state and result badge/title both used the custom version name (`Radical Red`, `Radical Red Nuzlocke`)